### PR TITLE
small change for Windows

### DIFF
--- a/core/hal/hal.cc
+++ b/core/hal/hal.cc
@@ -5,6 +5,7 @@
 #include "config.h"
 #include "constants.h"
 #include <fstream>
+#include <algorithm>
 
 using namespace pxar;
 

--- a/core/utils/log.h
+++ b/core/utils/log.h
@@ -6,6 +6,7 @@
 #define PXAR_LOG_H
 
 #ifdef WIN32
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <sys/time.h>


### PR DESCRIPTION
Make sure that on Windows the std::max from <algorithm> is
used instead of the max macro contained in windows.h (that
is the reason for adding the #define NOMINMAX in core/utils/log.h

This became necessary after Simon removed the using namespace std::
and added std:: everywhere. Suddenly std::max stopped working on
Windows (because max is apparently a macro in windows.h)
