### PR TITLE
Fix serial communication on OS X. 

### DIFF
--- a/devices/hvsupply.keithley2410.cc
+++ b/devices/hvsupply.keithley2410.cc
@@ -12,10 +12,11 @@
 #include <iostream>
 
 using namespace pxar;
+#define COM_PORT_NUMBER 30 //See listing in rs232.cc
 
 // ----------------------------------------------------------------------
 hvsupply::hvsupply() {
-  const int comPortNumber = 16; /* /dev/tty.KeySerial1 */
+  const int comPortNumber = COM_PORT_NUMBER;
   if(!openComPort(comPortNumber,57600)) {
     LOG(logCRITICAL) << "Error connecting via RS232 port!";
     throw UsbConnectionError("Error connecting via RS232 port!");

--- a/devices/rs232.cc
+++ b/devices/rs232.cc
@@ -37,27 +37,28 @@
 #include "log.h"
 
 using namespace pxar;
+#define NUMPORTS 31
 
-int Cport[30],
+int Cport[NUMPORTS],
   rs_error;
 
 struct termios new_port_settings,
-  old_port_settings[30];
+  old_port_settings[NUMPORTS];
 
-char comports[30][30]={"/dev/ttyS0","/dev/ttyS1","/dev/ttyS2","/dev/ttyS3","/dev/ttyS4","/dev/ttyS5",
+char comports[NUMPORTS][30]={"/dev/ttyS0","/dev/ttyS1","/dev/ttyS2","/dev/ttyS3","/dev/ttyS4","/dev/ttyS5",
                        "/dev/ttyS6","/dev/ttyS7","/dev/ttyS8","/dev/ttyS9","/dev/ttyS10","/dev/ttyS11",
-                       "/dev/ttyS12","/dev/ttyS13","/dev/ttyS14","/dev/ttyS15","/dev/tty.KeySerial1",
+                       "/dev/ttyS12","/dev/ttyS13","/dev/ttyS14","/dev/ttyS15","/dev/ttyUSB0",
                        "/dev/ttyUSB1","/dev/ttyUSB2","/dev/ttyUSB3","/dev/ttyUSB4","/dev/ttyUSB5",
                        "/dev/ttyAMA0","/dev/ttyAMA1","/dev/ttyACM0","/dev/ttyACM1",
-                       "/dev/rfcomm0","/dev/rfcomm1","/dev/ircomm0","/dev/ircomm1"};
+                       "/dev/rfcomm0","/dev/rfcomm1","/dev/ircomm0","/dev/ircomm1","/dev/tty.KeySerial1"};
 
-int comport_number=16; // "/dev/tty.KeySerial1"
+int comport_number=16; // "/dev/ttyUSB0"
 
 int RS232_OpenComport(int comport_number, int baudrate)
 {
   int baudr, status;
 
-  if((comport_number>29)||(comport_number<0))
+  if((comport_number>=NUMPORTS)||(comport_number<0))
     {
       LOG(logCRITICAL) << "Illegal comport number " << comport_number << "!";
       return(1);


### PR DESCRIPTION
The current implementation of rs232, used to do IV curve, doesn't work on OS X. This appears to be an issue with different implementations of **termios**. Specifically, `tcsetattr` would return an error with the given port settings. 

The solution, which I have tested both on an iMac and my laptop running Ubuntu, is to leave the default port settings unchanged except for modifying the baud rate. This of course depends on the default settings of the port being acceptable, but this appears to be the case on the platforms I tested. 

This PR aims to resolve #168 .
