### PR TITLE
ConfigParameters - getTbPgSetting() fixed

### DIFF
--- a/util/ConfigParameters.cc
+++ b/util/ConfigParameters.cc
@@ -312,15 +312,23 @@ vector<pair<string, uint8_t> >  ConfigParameters::getTbSigDelays() {
 vector<pair<std::string, uint8_t> >  ConfigParameters::getTbPgSettings() {
 
   vector<pair<std::string, uint8_t> > a;
+  
+  uint8_t wbc = 100;
+  vector<vector<pair<string, uint8_t> > > dacs = getRocDacs();
+  for (unsigned int idac = 0; idac < dacs[0].size(); ++idac) {
+	  if (!dacs[0][idac].first.compare("wbc")) {
+		  wbc = dacs[0][idac].second;
+	  }
+  }
 
   if (fnTbms < 1) {
     a.push_back(make_pair("resetroc",25));    // PG_RESR b001000 
-    a.push_back(make_pair("calibrate",100+6)); // PG_CAL  b000100
+    a.push_back(make_pair("calibrate",wbc+6)); // PG_CAL  b000100
     a.push_back(make_pair("trigger",16));    // PG_TRG  b000010
     a.push_back(make_pair("token",0));     // PG_TOK  b000001
   } else {
     a.push_back(std::make_pair("resettbm",15));    // PG_REST
-    a.push_back(std::make_pair("calibrate",100+6)); // PG_CAL
+    a.push_back(std::make_pair("calibrate",wbc+6)); // PG_CAL
     a.push_back(std::make_pair("trigger;sync",0));     // PG_TRG PG_SYNC
   }
 


### PR DESCRIPTION
Previously the cal delay in the default PG was fix to 100+6.
Now it is linked to the wbc as it has to be (wbc+6).

A further improvement can be to change it even after that  wbc is changed from the gui.
