### PR TITLE
fixed crash when starting IV test via console

### DIFF
--- a/tests/PixTestIV.cc
+++ b/tests/PixTestIV.cc
@@ -114,7 +114,7 @@ void PixTestIV::doTest() {
 
   PixTest::update();
 
-  gPad->SetLogy(1);
+  if(gPad) gPad->SetLogy(1);
 
   int tripped(-1);
 


### PR DESCRIPTION
When starting the IV test without the gui there is no gPad initialized.
