### PR TITLE
New User Test: "PixTestThreshMap"

### DIFF
--- a/usertests/PixTestThreshMap.cc
+++ b/usertests/PixTestThreshMap.cc
@@ -55,6 +55,10 @@ bool PixTestThreshMap::setParameter(string parName, string sval) {
 	fParHiDAC = static_cast<uint16_t>(atoi(sval.c_str())); 
 	setToolTips();
       }
+      if (!parName.compare("stepsize")) {
+	fParStepSize = static_cast<uint16_t>(atoi(sval.c_str())); 
+	setToolTips();
+      }
       if (!parName.compare("risingedge")) {
 	fParRisingEdge = atoi(sval.c_str()) != 0;
 	setToolTips();
@@ -140,7 +144,7 @@ void PixTestThreshMap::doTest() {
   uint16_t flags = 0;
   if(fParRisingEdge) flags |= FLAG_RISING_EDGE;
   if(fParCalS) flags |= FLAG_CALS;
-  std::vector<pixel> results = fApi->getThresholdMap(fParDac, 1, fParLoDAC,fParHiDAC,fParThresholdLevel,flags, fParNtrig);
+  std::vector<pixel> results = fApi->getThresholdMap(fParDac, fParStepSize, fParLoDAC,fParHiDAC,fParThresholdLevel,flags, fParNtrig);
    
   LOG(logINFO) << "Pixels returned: " << results.size();
 

--- a/usertests/PixTestThreshMap.hh
+++ b/usertests/PixTestThreshMap.hh
@@ -24,7 +24,8 @@ private:
   uint8_t fParThresholdLevel;
   uint16_t fParNtrig;
   int 	   fParLoDAC; 
-  int 	   fParHiDAC; 
+  int 	   fParHiDAC;
+  int      fParStepSize;
   bool     fParRisingEdge;
   bool     fParCalS;
 


### PR DESCRIPTION
Unleashing the full power of the pxarCore getThresholdMap interface:
- Configurable scanning step size
- DAC and DAC range adjustable
- Configurable threshold level (default: 50%)
- FLAG_RISING_EDGE checkbox to scan in both directions

To have this test showing up in your GUI, just add the following to your `testParameters.dat`:

```
-- ThreshMap
ntrig               10
dac                 vcal
daclo               0
dachi               255
stepsize            2
thresholdpercent    50
risingedge          checkbox
cals                checkbox
```
