### PR TITLE
Change Target Clock

### DIFF
--- a/main/mkConfig
+++ b/main/mkConfig
@@ -515,7 +515,7 @@ EOF
     print FH <<"EOF";
 -- Timing
 fastscan            checkbox(0)
-targetclk           5
+targetclk           4
 ntrig               10
 clocksdascan        button
 phasescan           button


### PR DESCRIPTION
Changed the target clock on the clk-sda scan such that if the DTB is working it will return the pXar default values, and maybe lead to less confusion.
