### PR TITLE
Timing Test Modification

### DIFF
--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -389,9 +389,8 @@ void PixTestPretest::setTimings() {
       fApi->setTbmReg("basee", TBMPhase, 0); //Set TBM PLL Phases
 
       //Loop through the different ROC delays (4, 3, 5, 2, 6, 1)
-      //int ROCDelays[6] = {4, 3, 5, 2, 6, 1};
-      int ROCDelays[2] = {4, 3};
-      for (int iROCDelay = 0; iROCDelay < 2 && !GoodDelaySettings; iROCDelay++) {
+      int ROCDelays[6] = {4, 3, 5, 2, 6, 1};
+      for (int iROCDelay = 0; iROCDelay < 6 && !GoodDelaySettings; iROCDelay++) {
         //Apply ROC Delays
         int ROCDelay = ROCDelays[iROCDelay];
         unsigned char ROCPhase = (1<<6) | (ROCDelay<<3) | ROCDelay; //Disable token delay, enable header/trailer delay, and set the ROC delays to the same values


### PR DESCRIPTION
Simon and Urs,

I changed the ROC delay range to scan in a more sensible order (4, 3, 5, 2, 6, 1). Also, I kept the default pg setup, as I think it's a more robust test of the timing.

Doug