### PR TITLE
New PH optimizaton test

### DIFF
--- a/main/mkConfig
+++ b/main/mkConfig
@@ -531,10 +531,10 @@ fit                 button
 save                button
 
 -- PhOptimization
- ntrig               10
- singlePix           0
- safetymarginlow     15
- safetymarginup      10
+ntrig               10
+safetymarginlow     20
+saturationvcal      100
+quantilesaturation  0.98
 
 -- Xray
 maskHotPixels       button

--- a/tests/PixTestPhOptimization.cc
+++ b/tests/PixTestPhOptimization.cc
@@ -3,6 +3,7 @@
 #include <sstream>   // parsing
 
 #include <TStopwatch.h>
+#include "constants.h"
 
 #include "PixTestPhOptimization.hh"
 #include "log.h"
@@ -14,7 +15,7 @@ ClassImp(PixTestPhOptimization)
 
 PixTestPhOptimization::PixTestPhOptimization() {}
 
-PixTestPhOptimization::PixTestPhOptimization( PixSetup *a, std::string name ) :  PixTest(a, name), fParNtrig(-1), fParDAC("nada"), fParDacVal(100),   fFlagSinglePix(true), fSafetyMarginUp(10), fSafetyMarginLow(15) {
+PixTestPhOptimization::PixTestPhOptimization( PixSetup *a, std::string name ) :  PixTest(a, name), fParNtrig(-1), fSafetyMarginLow(20), fQuantMax(0.98), fVcalMax(100) {
   PixTest::init();
   init();
 }
@@ -35,32 +36,20 @@ bool PixTestPhOptimization::setParameter(string parName, string sval) {
 	LOG(logDEBUG) << "  setting fParNtrig  ->" << fParNtrig
 		      << "<- from sval = " << sval;
       }
-      if (!parName.compare("safetymarginup")) {
-	fSafetyMarginUp = atoi( sval.c_str() );
-	LOG(logDEBUG) << "  setting fSafetyMarginUp  ->" << fSafetyMarginUp
-		      << "<- from sval = " << sval;
-      }
       if (!parName.compare("safetymarginlow")) {
 	fSafetyMarginLow = atoi( sval.c_str() );
 	LOG(logDEBUG) << "  setting fSafetyMarginLow  ->" << fSafetyMarginLow
 		      << "<- from sval = " << sval;
       }
-      if (!parName.compare("singlepix")) {
-	fFlagSinglePix = atoi( sval.c_str() );
-	LOG(logDEBUG) << "  setting fFlagSinglePix  ->" << fFlagSinglePix
-		      << "<- from sval = " << sval;
-      }
-      if (!parName.compare("dac")) {
-	setTestParameter("dac", sval); 
-	fParDAC = sval;
-	LOG(logDEBUG) << "  setting fParDAC  ->" << fParDAC
-		      << "<- from sval = " << sval;
-      }
 
-      if (!parName.compare("dacval")) {
-	setTestParameter("dacval", sval); 
-	fParDacVal = atoi(sval.c_str());
-	LOG(logDEBUG) << "  setting fParDacVal  ->" << fParDacVal
+      if (!parName.compare("saturationvcal")) {
+	fVcalMax = atoi(sval.c_str());
+	LOG(logDEBUG) << "  setting fVcalMax  ->" << fVcalMax
+		      << "<- from sval = " << sval;
+      }
+      if (!parName.compare("quantilesaturation")) {
+	fQuantMax = atof(sval.c_str());
+	LOG(logDEBUG) << "  setting fQuantMax  ->" << fQuantMax
 		      << "<- from sval = " << sval;
       }
       
@@ -102,7 +91,7 @@ void PixTestPhOptimization::doTest() {
   TStopwatch t;
 
   cacheDacs();
-  bigBanner(Form("PixTestPhOptimization::doTest() Ntrig = %d, singlePix = %d", fParNtrig, (fFlagSinglePix?1:0)));
+  bigBanner(Form("PixTestPhOptimization::doTest() Ntrig = %d", fParNtrig ));
   fDirectory->cd();
   PixTest::update();
 
@@ -129,33 +118,14 @@ void PixTestPhOptimization::doTest() {
   map<int, pxar::pixel> minpixels;
   map<int, int> minVcal;
   
-  if(fFlagSinglePix){
-    for (unsigned int iroc = 0; iroc < rocIds.size(); ++iroc){
-      LOG(logDEBUG)<<"**********Ph range will be optimised on a single random pixel***********";
-      pxar::pixel randomPix;
-      randomPix= *(RandomPixel(badPixels, rocIds[iroc]));
-      LOG(logDEBUG)<<"In doTest(), randomCol "<<(int)randomPix.column()<<", randomRow "<<(int)randomPix.row()<<", pixel "<<randomPix;
-      maxpixel.first = rocIds[iroc]; 
-      maxpixel.second.setRoc(rocIds[iroc]);
-      maxpixel.second.setColumn(randomPix.column());
-      maxpixel.second.setRow(randomPix.row());
-      minpixel.first = iroc; 
-      minpixel.second.setRoc(rocIds[iroc]);
-      minpixel.second.setColumn(randomPix.column());
-      minpixel.second.setRow(randomPix.row());
-      LOG(logDEBUG)<<"random pixel: "<<maxpixel.second<<", "<<minpixel.second<<"is not on the blacklist";
-      maxpixels.insert(maxpixel);
-      minpixels.insert(minpixel);
-    }
-  }
-  else{
-    LOG(logDEBUG)<<"**********Ph range will be optimised on the whole ROC***********";
-    //getting highest ph pixel
-    GetMaxPhPixel(maxpixels, badPixels);
-    //getting min ph pixel and finding its vcal threshold
-    GetMinPhPixel(minpixels, minVcal, badPixels);
-  }
 
+  LOG(logDEBUG)<<"**********Ph range will be optimised on the whole ROC***********";
+  //getting highest ph pixel
+  GetMaxPhPixel(maxpixels, badPixels);
+  //getting min ph pixel and finding its vcal threshold
+  GetMinPhPixel(minpixels, minVcal, badPixels);
+
+  
   for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
     LOG(logDEBUG)<<"vcal min "<<minVcal[roc_it]<<" on ROC"<<(int)rocIds[roc_it];
   }
@@ -166,24 +136,38 @@ void PixTestPhOptimization::doTest() {
   MaxPhVsDacDac(dacdac_max, maxpixels);
   MinPhVsDacDac(dacdac_min, minpixels, minVcal);
 
+
   //search for optimal dac values in 3 steps
   //1. shrinking the PH to be completely inside the ADC range, adjusting phscale
   map<uint8_t, int> ps_opt, po_opt;
   for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
     po_opt[rocIds[roc_it]] = 120;
   }
-  ps_opt = InsideRangePH(po_opt, dacdac_max, dacdac_min);
-  //check for opt failure
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    if(ps_opt[rocIds[roc_it]]==999){
-      LOG(logDEBUG)<<"PH optimization failed on ROC "<<(int)rocIds[roc_it]<<endl<<"Please run PreTest or try PhOptimization on a random pixel";
-    }
-  }
-  //2. centring PH curve adjusting phoffset
-  po_opt = CentrePhRange(po_opt, ps_opt, dacdac_max, dacdac_min);
   
-  //3. stretching curve adjusting phscale
-  ps_opt = StretchPH(po_opt, ps_opt, dacdac_max, dacdac_min);
+  //new approach
+  std::vector<TH2D* > th2_max;
+  std::vector<TH2D* > th2_min;
+  std::vector<TH2D* > th2_sol;
+  TH2D* h2(0);
+  unsigned int NRocs = fApi->_dut->getNRocs();
+  for(unsigned int iroc=0; iroc< NRocs; iroc++){
+    th2_max.push_back(h2);	   
+    th2_min.push_back(h2);	
+    th2_sol.push_back(h2);    
+  }
+    
+  getTH2fromMaps(dacdac_max, dacdac_min, th2_max, th2_min);
+  
+  for(unsigned int ih2 = 0; ih2< NRocs; ih2++){
+    fHistList.push_back(th2_max[ih2]);  
+    fHistOptions.insert( make_pair(th2_max[ih2], "colz" ) ); 
+    fHistList.push_back(th2_min[ih2]);  
+    fHistOptions.insert( make_pair(th2_min[ih2], "colz" ) ); 
+  }
+  
+  optimiseOnMapsNew(po_opt, ps_opt, th2_max, th2_min, th2_sol);
+  
+  LOG(logDEBUG)<<"optimisation done";
   
   //set optimized dacs and save
   restoreDacs();
@@ -192,19 +176,19 @@ void PixTestPhOptimization::doTest() {
     fApi->setDAC("phoffset",po_opt[rocIds[roc_it]], rocIds[roc_it]);
   }
   saveDacs();
-
+  
   cacheDacs(); 
   //draw figures of merit of optimization
   DrawPhMaps(minVcal, badPixels);
   DrawPhCurves(maxpixels, minpixels, po_opt, ps_opt);
   restoreDacs();
-
+  
   for (list<TH1*>::iterator il = fHistList.begin(); il != fHistList.end(); ++il) {
     (*il)->Draw(getHistOption(*il).c_str());
     PixTest::update();
   }
   fDisplayedHist = find(fHistList.begin(), fHistList.end(), h1);
-
+  
   // -- print summary information
   string psString(""), poString(""); 
   for (unsigned int i = 0; i < rocIds.size(); ++i) {
@@ -280,154 +264,308 @@ pxar::pixel* PixTestPhOptimization::RandomPixel(std::vector<std::pair<uint8_t, p
 
 void PixTestPhOptimization::GetMaxPhPixel(map<int, pxar::pixel > &maxpixels,   std::vector<std::pair<uint8_t, pair<int,int> > >  &badPixels){
   //looks for the pixel with the highest Ph at vcal = 255, taking care the pixels are not already saturating (ph=255)
-    fApi->_dut->testAllPixels(true);
-    fApi->_dut->maskAllPixels(false);
-    vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
-    bool isPixGood=true;
-    int maxph = 255;
-    fApi->setDAC("phoffset", 200);
-    int init_phScale =200;
-    int flag_maxPh=0;
-    pair<int, pxar::pixel> maxpixel;
-    maxpixel.second.setValue(0);
-    std::vector<pxar::pixel> result;
-    while((maxph>254 || maxph==0) && flag_maxPh<52){
-      result.clear();
-      fApi->setDAC("phscale", init_phScale);
-      fApi->setDAC("vcal",255);
-      fApi->setDAC("ctrlreg",4);
-      fApi->setDAC("phoffset",200);  
-      int cnt(0); 
-      bool done(false);
-      while (!done) {
-	try {
-	  result = fApi->getPulseheightMap(0, 10);
-	  done = true;
-	} catch(pxarException &e) {
-	  LOG(logCRITICAL) << "pXar execption: "<< e.what(); 
-	  ++cnt;
+  std::string rocType = fPixSetup->getConfigParameters()->getRocType();
+  bool isRoc21 = true;
+  if(!(rocType > "psi46digv2")){
+    isRoc21 = false;
+  }
+  if(isRoc21){LOG(logDEBUG)<<"ROC type is newer than digv2";}
+  LOG(logDEBUG)<<"ROC type is "<<rocType;
+  fApi->_dut->testAllPixels(true);
+  fApi->_dut->maskAllPixels(false);
+  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
+  bool isPixGood=true;
+  int maxph = 255;
+  fApi->setDAC("phoffset", 200);
+  int init_phScale =200;
+  int init_phOffset = 150;
+  if(!isRoc21){
+    init_phScale = 110;
+    init_phOffset = 220;
+  }
+  int flag_maxPh=0;
+  pair<int, pxar::pixel> maxpixel;
+  maxpixel.second.setValue(0);
+  std::vector<pxar::pixel> result;
+  std::vector<TH2D*> maxphmap;
+  int xbinmax=0, ybinmax=0, zbinmax=0;
+  int colmax=0, rowmax=0;
+  while((maxph>254 || maxph==0) && flag_maxPh<52){
+    fApi->setDAC("phscale", abs(init_phScale)%255);
+    fApi->setDAC("phoffset",init_phOffset);  
+    fApi->setDAC("vcal",255);
+    fApi->setDAC("ctrlreg",4);
+    maxphmap = phMaps("maxphmap", 10, 0);
+    
+    maxph=0;
+    //check that the pixel showing highest PH on the module is not reaching 255
+    for( unsigned int ith2 = 0; ith2 < maxphmap.size(); ith2++) {
+      isPixGood=true;
+      maxphmap[ith2]->GetBinXYZ(maxphmap[ith2]->GetMaximumBin(), xbinmax, ybinmax, zbinmax);
+      colmax = maxphmap[ith2]->GetXaxis()->GetBinCenter(xbinmax);
+      rowmax = maxphmap[ith2]->GetYaxis()->GetBinCenter(ybinmax);
+      for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
+	if(bad_it->second.first == colmax && bad_it->second.second == rowmax && bad_it->first == getIdFromIdx(ith2)){
+	  isPixGood=false;
 	}
-	done = (cnt>5) || done;
       }
-      
-      maxph=0;
-      LOG(logDEBUG) << "result size "<<result.size()<<endl;
-      //check that the pixel showing highest PH on the module is not reaching 255
-      for(std::vector<pxar::pixel>::iterator px = result.begin(); px != result.end(); px++) {
-	isPixGood=true;
-	for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
-	  if(bad_it->second.first == px->column() && bad_it->second.second == px->row() && bad_it->first == px->roc()){
-	    isPixGood=false;
-	  }
+      if(isPixGood && maxphmap[ith2]->GetBinContent(xbinmax, ybinmax) > maxph){
+	maxph = maxphmap[ith2]->GetBinContent(xbinmax, ybinmax);
 	}
-	if(isPixGood && px->value() > maxph){
-	  maxph = px->value();
-	}
-      }
-      //should have flag for v2 or v2.1
-      init_phScale+=5;
-      flag_maxPh++;
     }
-    // Look for pixel with max. pulse height on every ROC:
-    for(unsigned int iroc=0; iroc< rocIds.size(); iroc++){
-      maxph=0;
-      for(std::vector<pxar::pixel>::iterator px = result.begin(); px != result.end(); px++) {
-	isPixGood=true;
-	if(px->value() > maxph && px->roc() == rocIds[iroc]){
+    //should have flag for v2 or v2.1
+//    if(!isRoc21){
+//      init_phScale-=5;
+//    }
+//    else{
+      init_phScale+=5;
+      //    }
+     
+    flag_maxPh++;
+  }
+  
+  for( unsigned int ith2 = 0; ith2 < maxphmap.size(); ith2++) {
+    fHistList.push_back(maxphmap[ith2]);  
+    fHistOptions.insert( make_pair(maxphmap[ith2], "colz" ) ); 
+  }
+  
+  std::map<uint8_t, std::pair<uint8_t, uint8_t> > maxpixs;
+  pxar::pixel temp_pix;
+  Double_t xq[1]={0};  // position where to compute the quantiles in [0,1]
+  xq[0]=fQuantMax;
+  Double_t yq[1]={0};  // array to contain the quantiles
+  // Look for pixel with max. pulse height on every ROC:
+  for(unsigned int ith2 = 0; ith2 < maxphmap.size(); ith2++) {
+    TH1D* h_quant = distribution(maxphmap[ith2], 256, 0., 255.);
+    fHistList.push_back(h_quant);
+    h_quant->GetQuantiles(1, yq, xq);
+    LOG(logDEBUG)<<"maxph quantile "<<yq[0];
+    int colMargin = 3;
+    int rowMargin = 5; 
+    bool pix_found = false;
+    bool badpix = false;
+    //first, pixel search excludes edges (col(row)Margin cols (rows) per side)
+    for(int ibinx = 1 + colMargin; ibinx < maxphmap[ith2]->GetNbinsX()+1-colMargin; ibinx++){
+      if(pix_found) break;
+      for(int ibiny = 1 + rowMargin; ibiny < maxphmap[ith2]->GetNbinsY()+1 - rowMargin; ibiny++){
+	//try to avoid picking edge pixels
+	ibinx = (ibinx)%maxphmap[ith2]->GetNbinsX();
+	ibiny = (ibiny)%maxphmap[ith2]->GetNbinsY();
+	if( abs( maxphmap[ith2]->GetBinContent(ibinx, ibiny) - yq[0] ) < 1){
+	  temp_pix.setRoc( getIdFromIdx(ith2) );
+	  temp_pix.setRow( ibiny - 1 );
+	  temp_pix.setColumn( ibinx - 1 );
 	  for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
-	    if(bad_it->second.first == px->column() && bad_it->second.second == px->row() && bad_it->first == px->roc()){
-	      isPixGood=false;
+	    if(bad_it->second.first == ibinx && bad_it->second.second == ibiny && bad_it->first == getIdFromIdx(ith2)){
+	      badpix=true;
 	      break;
 	    }
 	  }
-	  if(isPixGood){
-	    maxpixel = make_pair(iroc,*px);
-	    maxph = px->value();
-	    }
+	  if(badpix) continue;
+	  temp_pix.setValue( maxphmap[ith2]->GetBinContent(ibinx,ibiny) );
+	  LOG(logDEBUG)<<"Max pixel is ["<<(int)temp_pix.column()<<" ,"<<(int)temp_pix.row()<<"]"<<" phvalue "<<maxphmap[ith2]->GetBinContent(ibinx, ibiny);
+	  maxpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));
+	  pix_found=true;
+	  break;
 	}
       }
-      maxpixels.insert(maxpixel);
-      LOG(logDEBUG) << "maxPh " << maxph <<" for ROC "<<maxpixel.first<<" on pixel "<<maxpixel.second << endl ;      
     }
+    //if not found, look outside fiducial region
+    if(!pix_found){
+      badpix=false;
+      LOG(logDEBUG)<<"Search for maxph pixel failed in the fiducial region on chip "<< (int)getIdFromIdx(ith2)<<", looking at the edges";
+      for(int ibinx_ex = maxphmap[ith2]->GetNbinsX()+1-colMargin; ibinx_ex < maxphmap[ith2]->GetNbinsX()+1+colMargin; ibinx_ex++){
+	if(pix_found) break;
+	for(int ibiny_ex = maxphmap[ith2]->GetNbinsY()+1 - rowMargin; ibiny_ex < maxphmap[ith2]->GetNbinsY()+1 + rowMargin; ibiny_ex++){
+	  //try to avoid picking edge pixels
+	  int ibinx = (ibinx_ex)%maxphmap[ith2]->GetNbinsX();
+	  int ibiny = (ibiny_ex)%maxphmap[ith2]->GetNbinsY();
+	  if( abs( maxphmap[ith2]->GetBinContent(ibinx, ibiny) - yq[0] ) < 1){
+	    temp_pix.setRoc( getIdFromIdx(ith2) );
+	    temp_pix.setRow( ibiny - 1 );
+	    temp_pix.setColumn( ibinx - 1 );
+	    for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
+	      if(bad_it->second.first == ibinx && bad_it->second.second == ibiny && bad_it->first == getIdFromIdx(ith2)){
+		badpix=true;
+		break;
+	      }
+	    }
+	    if(badpix) continue;
+	    temp_pix.setValue( maxphmap[ith2]->GetBinContent(ibinx,ibiny) );
+	    LOG(logDEBUG)<<"Max pixel is ["<<(int)temp_pix.column()<<" ,"<<(int)temp_pix.row()<<"]"<<" phvalue "<<maxphmap[ith2]->GetBinContent(ibinx, ibiny);
+	    maxpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));
+	    pix_found=true;
+	    break;
+	  }
+	}
+      }
+    }
+    if(!pix_found){
+      LOG(logDEBUG)<<"max ph pixel determination failed on roc "<<getIdFromIdx(ith2)<<", setting pixel 0,0";
+      temp_pix.setRoc( getIdFromIdx(ith2) ); 
+      temp_pix.setRow( 0 );
+      temp_pix.setColumn( 0 );
+      temp_pix.setValue( -1 );
+      maxpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));   
+    }
+  }
 }
 
 void PixTestPhOptimization::GetMinPhPixel(map<int, pxar::pixel > &minpixels, map<int, int> &minVcal, std::vector<std::pair<uint8_t, pair<int,int> > >  &badPixels){
-  //looks for the pixel with the lowest Ph at vcal = 1.2*trimValue, taking care the pixels are correclty responding (ph>0)
+  //looks for the pixel with the lowest Ph at vcal = 60 low range, taking care the pixels are correclty responding (ph>0)
   //finds the min vcal at which the minphpixel can be sampled
+  std::string rocType = fPixSetup->getConfigParameters()->getRocType();
+  bool isRoc21 = true;
+  if(!(rocType > "psi46digv2")){
+    isRoc21 = false;
+  }
+  if(isRoc21){LOG(logDEBUG)<<"ROC type is newer than digv2";}
+  LOG(logDEBUG)<<"ROC type is "<<rocType;
   fApi->_dut->testAllPixels(true);
   fApi->_dut->maskAllPixels(false);
   vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
   bool isPixGood=true;
   int minph = 0;
-  int init_phScale = 100;
+  int init_phScale = 150;
+  int init_phOffset = 175;
+  if(!isRoc21){
+    init_phScale = 90;
+    init_phOffset = 220;
+  } 
   int flag_minPh=0;
   pair<int, pxar::pixel> minpixel;
   minpixel.second.setValue(0);
   std::vector<pxar::pixel> result;
-  while(minph<1 && flag_minPh<52){
-    result.clear();
-    fApi->setDAC("phscale", init_phScale);
+  std::vector<TH2D*> minphmap;
+  int xbinmin=0, ybinmin=0, zbinmin=0;
+  int colmin=0, rowmin=0;
+  int minph_roc = -1;
+  while(minph<12 && flag_minPh<52){
+    LOG(logDEBUG) << "init_phScale=" << init_phScale << ", flag_minPh = " << flag_minPh << ", minph = " << minph;
+    fApi->setDAC("phscale", init_phScale%255);
+    fApi->setDAC("phoffset",init_phOffset);  
     fApi->setDAC("ctrlreg",0);
-    //    fApi->setDAC("vcal",fMinThr*1.2);
-    fApi->setDAC("vcal",130);
-    fApi->setDAC("phoffset",150);  
-    int cnt(0); 
-    bool done(false);
-    int size = 0;
-    while (!(done && size !=0)) {
-      try {
-	result = fApi->getPulseheightMap(0, 10);
-	size = result.size();
-	++cnt;
-	done = true;
-      } catch(pxarException &e) {
-	LOG(logCRITICAL) << "pXar execption: "<< e.what(); 
-	++cnt;
-	}
-      done = (cnt>5) || done;
-    }
+    fApi->setDAC("vcal",60);
+    minphmap = phMaps("minphmap", 10, 0);
     minph=255;
     LOG(logDEBUG) << "result size "<<result.size()<<endl;
     //check that the pixel showing lowest PH above 0 on the module
-    for(std::vector<pxar::pixel>::iterator px = result.begin(); px != result.end(); px++) {
+    for(unsigned int ith2 = 0; ith2 < minphmap.size(); ith2++) {
       isPixGood=true;
+      minphmap[ith2]->GetBinXYZ(minphmap[ith2]->GetMinimumBin(), xbinmin, ybinmin, zbinmin);
+      colmin = minphmap[ith2]->GetXaxis()->GetBinCenter(xbinmin);
+      rowmin = minphmap[ith2]->GetYaxis()->GetBinCenter(ybinmin);
       for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
-	if(bad_it->second.first == px->column() && bad_it->second.second == px->row() && bad_it->first == px->roc()){
+	if(bad_it->second.first == colmin && bad_it->second.second == rowmin && bad_it->first == getIdFromIdx(ith2)){
 	  isPixGood=false;
-	  break;
-	  }
+	}
       }
-      if(isPixGood && px->value() < minph){
-	minph = px->value();
+      if(isPixGood && minphmap[ith2]->GetBinContent(xbinmin, ybinmin) < minph){
+	minph = minphmap[ith2]->GetBinContent(xbinmin, ybinmin);
+	minph_roc = ith2;
       }
     }
     //should have flag for v2 or v2.1
-    init_phScale+=5;
+//    if(!isRoc21){
+//      init_phScale-=5;
+//    }
+//    else{
+      init_phScale+=5;
+      //    }
+    
     flag_minPh++;
   }
+  LOG(logDEBUG) << "done. init_phScale=" << init_phScale << ", flag_minPh = " << flag_minPh << ", minph = " << minph << "minph_roc = " << minph_roc;
+  
+  for(unsigned int ith2 = 0; ith2 < minphmap.size(); ith2++) {
+    fHistList.push_back(minphmap[ith2]);  
+    fHistOptions.insert(make_pair(minphmap[ith2], "colz")  ); 
+  }
   // Look for pixel with min pulse height on every ROC:
-  for(unsigned int iroc=0; iroc< rocIds.size(); iroc++){
-    minph=255;
-    for(std::vector<pxar::pixel>::iterator px = result.begin(); px != result.end(); px++) {
-      isPixGood=true;
-      if(px->value() < minph && px->roc() == rocIds[iroc]){
-	for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
-	  if(bad_it->second.first == px->column() && bad_it->second.second == px->row() && bad_it->first == px->roc()){
-	    isPixGood=false;
-	    break;
+  std::map<uint8_t, std::pair<uint8_t, uint8_t> > minpixs;
+  pxar::pixel temp_pix;
+  Double_t xq[1];  // position where to compute the quantiles in [0,1]
+  xq[0]=0.02;
+  Double_t yq[1];  // array to contain the quantiles
+  // Look for pixel with min. pulse height on every ROC:
+  for(unsigned int ith2 = 0; ith2 < minphmap.size(); ith2++) {
+    TH1D* h_quant = distribution(minphmap[ith2], 256, 0., 255.);
+    fHistList.push_back(h_quant);
+    h_quant->GetQuantiles(1, yq, xq);
+    //    yq[0] = h_quant->FindFirstBinAbove(1.) + 1;
+    LOG(logDEBUG)<<"minph quantile "<<xq[0]<<" "<<yq[0];
+    int colMargin = 3;
+    int rowMargin = 5; 
+    bool pix_found = false;
+    bool badpix = false;
+    //first, pixel search excludes edges (col(row)Margin cols (rows) per side)
+    for(int ibinx = 1 + colMargin; ibinx < minphmap[ith2]->GetNbinsX()+1-colMargin; ibinx++){
+      if(pix_found) break;
+      for(int ibiny = 1 + rowMargin; ibiny < minphmap[ith2]->GetNbinsY()+1 - rowMargin; ibiny++){
+	//try to avoid picking edge pixels
+	ibinx = (ibinx)%minphmap[ith2]->GetNbinsX();
+	ibiny = (ibiny)%minphmap[ith2]->GetNbinsY();	  
+	if( abs( minphmap[ith2]->GetBinContent(ibinx, ibiny) - yq[0] ) <= 1){
+	  temp_pix.setRoc( getIdFromIdx(ith2) );
+	  temp_pix.setRow( ibiny - 1 );
+	  temp_pix.setColumn( ibinx - 1 );
+	  for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
+	    if(bad_it->second.first == ibinx && bad_it->second.second == ibiny && bad_it->first == getIdFromIdx(ith2)){
+	      badpix=true;
+	      break;
+	    }
 	  }
-	}
-	if(isPixGood){
-	  minpixel = make_pair(iroc,*px);
-	  minph = px->value();
+	  if(badpix) continue;
+	  LOG(logDEBUG)<<"Min pixel is ["<<(int)temp_pix.column()<<" ,"<<(int)temp_pix.row()<<"]"<<" phvalue "<<minphmap[ith2]->GetBinContent(ibinx, ibiny);
+	  temp_pix.setValue( minphmap[ith2]->GetBinContent(ibinx,ibiny) );
+	  minpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));
+	  pix_found = true;
+	  break;
 	}
       }
     }
-    minpixels.insert(minpixel);
-    LOG(logDEBUG) << "minPh " << minph <<" for ROC "<<minpixel.first<<" on pixel "<<minpixel.second << endl ;      
+    
+    //if not found, look outside fiducial region
+    if(!pix_found){
+      badpix = false;
+      LOG(logDEBUG)<<"Search for minph pixel failed in the fiducial region for chip "<< (int)getIdFromIdx(ith2)<<", looking at the edges";
+      for(int ibinx_ex = minphmap[ith2]->GetNbinsX()+1-colMargin; ibinx_ex < minphmap[ith2]->GetNbinsX()+1+colMargin; ibinx_ex++){
+	if(pix_found) break;
+	for(int ibiny_ex = minphmap[ith2]->GetNbinsY()+1 - rowMargin; ibiny_ex < minphmap[ith2]->GetNbinsY()+1 + rowMargin; ibiny_ex++){
+	  //ibinx_ex, ibiny_ex extend beyond the range so wrap around 
+	  int ibinx = (ibinx_ex)%minphmap[ith2]->GetNbinsX();
+	  int ibiny = (ibiny_ex)%minphmap[ith2]->GetNbinsY();
+	  if( abs( minphmap[ith2]->GetBinContent(ibinx, ibiny) - yq[0] ) <= 1){
+	    temp_pix.setRoc( getIdFromIdx(ith2) );
+	    temp_pix.setRow( ibiny - 1 );
+	    temp_pix.setColumn( ibinx - 1 );
+	    for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
+	      if(bad_it->second.first == ibinx && bad_it->second.second == ibiny && bad_it->first == getIdFromIdx(ith2)){
+		badpix=true;
+		break;
+	      }
+	    }
+	    if(badpix) continue;
+	    LOG(logDEBUG)<<"Min pixel is ["<<(int)temp_pix.column()<<" ,"<<(int)temp_pix.row()<<"]"<<" phvalue "<<minphmap[ith2]->GetBinContent(ibinx, ibiny);
+	    temp_pix.setValue( minphmap[ith2]->GetBinContent(ibinx,ibiny) );
+	    minpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));
+	    pix_found = true;
+	    break;
+	  }
+	}
+      }
+    }
+    if(!pix_found){
+      LOG(logDEBUG)<<"min ph pixel determination failed on roc "<<getIdFromIdx(ith2)<<", setting pixel 0,0";
+      temp_pix.setRoc( getIdFromIdx(ith2) ); 
+      temp_pix.setRow( 0 );
+      temp_pix.setColumn( 0 );
+      temp_pix.setValue( -1 );
+      minpixels.insert(make_pair(getIdFromIdx(ith2), temp_pix));   
+    }
   }
-  
   //finds min vcal
+  fApi->setDAC("ctrlreg",0);
   int cnt(0); 
   bool done(false);
   TH1D *h1(0); 
@@ -442,9 +580,6 @@ void PixTestPhOptimization::GetMinPhPixel(map<int, pxar::pixel > &minpixels, map
     }
     fApi->_dut->testAllPixels(false);
     fApi->_dut->maskAllPixels(true);
-    //    fApi->_dut->setROCEnable(roc_it, true);
-    //    fApi->_dut->testPixel(minpixels[rocIds[roc_it]].column(), minpixels[rocIds[roc_it]].row(), true, rocIds[roc_it]);
-    //    fApi->_dut->maskPixel(minpixels[rocIds[roc_it]].column(), minpixels[rocIds[roc_it]].row(), false, rocIds[roc_it]);
     fApi->_dut->testPixel(minpixels[rocIds[roc_it]].column(), minpixels[rocIds[roc_it]].row(), true);
     fApi->_dut->maskPixel(minpixels[rocIds[roc_it]].column(), minpixels[rocIds[roc_it]].row(), false);
     LOG(logDEBUG)<<"enabling pixels "<<(int)minpixels[roc_it].column()<<", "<<(int)minpixels[roc_it].row()<<", "<<(int)minpixels[roc_it].roc()<<" "<<(int)roc_it;
@@ -453,16 +588,12 @@ void PixTestPhOptimization::GetMinPhPixel(map<int, pxar::pixel > &minpixels, map
 	fApi->_dut->setROCEnable(roc_jt, false);
       }
     }
-    //    fApi->_dut->testPixel(minpixels[roc_it].column(), minpixels[roc_it].row(), true, getIdFromIdx((int)roc_it));
-    //fApi->_dut->maskPixel(minpixels[roc_it].column(), minpixels[roc_it].row(), false, getIdFromIdx((int)roc_it));
     fApi->_dut->info();
     cnt = 0; 
     done = false;
     while (!done) {
       try {
-	//	LOG(logDEBUG)<<"trying phVsDAC for roc "<<(int)roc_it<<" "<<(int)rocIds[roc_it];
 	results = fApi->getPulseheightVsDAC("vcal", 0, 255, FLAG_FORCE_MASKED, 10);
-	//LOG(logDEBUG)<<"worked? phVsDAC for roc "<<(int)roc_it<<" "<<(int)rocIds[roc_it];
 	done = true;
       } catch(pxarException &e) {
 	LOG(logCRITICAL) << "pXar execption: "<< e.what(); 
@@ -473,18 +604,14 @@ void PixTestPhOptimization::GetMinPhPixel(map<int, pxar::pixel > &minpixels, map
     
     LOG(logDEBUG)<<"size of results "<<results.size();
     for (unsigned int i = 0; i < results.size(); ++i) {
-      //      LOG(logDEBUG)<<"analyzing postion "<<int(i)<<" of results";
       pair<uint8_t, vector<pixel> > v = results[i];
       int idac = v.first; 
-      // LOG(logDEBUG)<<"idac is "<<(int)idac;
       vector<pixel> vpix = v.second;
-      //LOG(logDEBUG)<<"vpix size is "<<vpix.size();
       for (unsigned int ipix = 0; ipix < vpix.size(); ++ipix) {
-	//	LOG(logDEBUG)<<"vcalmin loop: ipix = "<<ipix<<", dac = "<<idac<<", ph = "<<vpix[ipix].value();
 	h1->Fill(idac, vpix[ipix].value());
       }
     }
-    vcalthr = static_cast<int>( h1->GetBinCenter( h1->FindFirstBinAbove(1.) ) );
+    vcalthr = static_cast<int>( h1->GetBinCenter( h1->FindFirstBinAbove(10.) ) );
     vcalmin = make_pair(roc_it, vcalthr);
     minVcal.insert(vcalmin);
     h1->Reset();
@@ -497,251 +624,124 @@ void PixTestPhOptimization::GetMinPhPixel(map<int, pxar::pixel > &minpixels, map
   }
 }
 
-map<uint8_t, int> PixTestPhOptimization::InsideRangePH(map<uint8_t,int> &po_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min){
-  //adjusting phscale so that the PH curve is fully inside the ADC range
-  map<uint8_t, int> ps_opt;
-  int maxPh(0);
-  int minPh(0);
-  bool lowEd=false, upEd=false;
-  int upEd_dist=255, lowEd_dist=255;
-  int safetyMargin = 40;
-  int dist = 255;
-  map<uint8_t, int> bestDist;
-  LOG(logDEBUG) << "dacdac at max vcal has size "<<dacdac_max.size()<<endl;
-  LOG(logDEBUG) << "dacdac at min vcal has size "<<dacdac_min.size()<<endl;
-  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    bestDist[rocIds[roc_it]] = 255;
-    LOG(logDEBUG)<<"Bestdist at roc_it "<<roc_it<<" initialized with "<<bestDist[roc_it]<<" "<<bestDist[rocIds[roc_it]];
-    ps_opt[rocIds[roc_it]] = 999;
-  }
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin();
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin();
-//  for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
-//    for(int pixit = 0; pixit < dacit_max->second.second.size(); pixit++){
-//      LOG(logDEBUG)<<"dacit_max: pixel "<<(int)dacit_max->second.second[pixit].roc()<<", "<<(int)dacit_max->second.second[pixit].column()<<", "<<(int)dacit_max->second.second[pixit].row()<<", ph offset "<<(int)dacit_max->first<<", ph scale "<<(int)dacit_max->second.first<<", max ph "<<(int)dacit_max->second.second[pixit].value();
-//      LOG(logDEBUG)<<"dacit_min: pixel "<<(int)dacit_min->second.second[pixit].roc()<<", "<<(int)dacit_min->second.second[pixit].column()<<", "<<(int)dacit_min->second.second[pixit].row()<<", ph offset "<<(int)dacit_min->first<<", ph scale "<<(int)dacit_min->second.first<<", min ph "<<(int)dacit_min->second.second[pixit].value();
-//    }
-//    dacit_min++;
-//  }
-  int pixsize_max=0;
-  int pixsize_min=0;
-  LOG(logDEBUG)<<"InsideRange() subtest";
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
-      if(dacit_max->first == po_opt[rocIds[roc_it]]){
-	for(dacit_min = dacdac_min.begin(); dacit_min != dacdac_min.end(); dacit_min++)
-	  if(dacit_min->first == po_opt[rocIds[roc_it]] && dacit_min->second.first == dacit_max->second.first){
-    	    pixsize_max = dacit_max->second.second.size();
-	    pixsize_min = dacit_min->second.second.size();
-    	    for(int pix=0; pix < pixsize_max; pix++){
-	      if((dacit_max->second.second[pix].roc()!=rocIds[roc_it] || dacit_min->second.second[pix].roc()!=rocIds[roc_it]) && dacit_max->second.second[pix].roc() != dacit_min->second.second[pix].roc()){
-		//	LOG(logDEBUG)<<"####//// this time roc ids DO NOT match "<<(int)dacit_min->second.second[pix].roc()<<" "<<(int)dacit_max->second.second[pix].roc()<<" "<<(int)rocIds[roc_it]<<" "<<(int)roc_it<<" ////####";
-		continue;
-	      }
-	      //LOG(logDEBUG)<<"####//// this time roc ids match "<<(int)rocIds[roc_it]<<" "<<(int)roc_it<<" ////####";
-	      maxPh=dacit_max->second.second[pix].value();
-	      minPh=dacit_min->second.second[pix].value();
-	      if(dacit_max->second.second[pix].roc() != dacit_min->second.second[pix].roc()){
-		LOG(logDEBUG) << "InsideRangePH: ROC ids do not correspond";
-	      }
-	      lowEd = (minPh > safetyMargin);
-	      upEd = (maxPh < 255 - safetyMargin);
-	      lowEd_dist = abs(minPh - safetyMargin);
-	      upEd_dist = abs(maxPh - (255 - safetyMargin));
-	      dist = (upEd_dist > lowEd_dist ) ? (upEd_dist) : (lowEd_dist);
-	      if(dist < bestDist[dacit_max->second.second[pix].roc()] && upEd && lowEd){
-		LOG(logDEBUG)<<"New distance "<<dist<<" is smaller than previous bestDist "<<bestDist[dacit_max->second.second[pix].roc()]<<" and edges are ok, so... ";
-		ps_opt[dacit_max->second.second[pix].roc()] = dacit_max->second.first;
-		bestDist[dacit_max->second.second[pix].roc()]=dist;
-		LOG(logDEBUG)<<"... new bestDist is "<<bestDist[dacit_max->second.second[pix].roc()]<<" for ps_opt = "<<ps_opt[dacit_max->second.second[pix].roc()];
-	      }
-	    }
-	  }
-      }
-    }
-  }
-  
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    LOG(logDEBUG)<<"opt step 1: po fixed to"<<po_opt[rocIds[roc_it]]<<" and scale adjusted to "<<ps_opt[rocIds[roc_it]]<<" for ROC "<<(int)rocIds[roc_it]<<", with distance "<<bestDist[rocIds[roc_it]];
-  }
-  return ps_opt;
-}
-
-map<uint8_t, int> PixTestPhOptimization::CentrePhRange(map<uint8_t, int> &po_opt, map<uint8_t, int> &ps_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min){
-  //centring PH curve adjusting phoffset   
-  LOG(logDEBUG)<<"Welcome to CentrePhRange()"; 
-  int maxPh(0);
-  int minPh(0);
-  int dist = 255;
-  map<uint8_t, int> bestDist;
-  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    bestDist[rocIds[roc_it]] = 255;
-  }
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin();
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin();
-  int pixsize_max=0;
-  int pixsize_min=0;
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    dist = 255;
-    for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
-      if(dacit_max->second.first != ps_opt[rocIds[roc_it]])continue;
-      for(dacit_min = dacdac_min.begin(); dacit_min != dacdac_min.end(); dacit_min++){
-	if(dacit_min->second.first == ps_opt[rocIds[roc_it]] && dacit_min->first == dacit_max->first){
-	  pixsize_max = dacit_max->second.second.size();
-	  pixsize_min = dacit_min->second.second.size();
-	  for(int pix=0; pix < pixsize_max; pix++){
-	    if(dacit_max->second.second[pix].roc()!=rocIds[roc_it] || dacit_min->second.second[pix].roc()!=rocIds[roc_it]) continue;
-	    maxPh=dacit_max->second.second[pix].value();
-	    minPh=dacit_min->second.second[pix].value();
-	    if(dacit_max->second.second[pix].roc() != dacit_min->second.second[pix].roc()){
-	      LOG(logDEBUG) << "CentrePhRange: ROC ids do not correspond";
-	    }
-	    dist = abs(minPh - (255 - maxPh));
-	    if (dist < bestDist[dacit_max->second.second[pix].roc()]){
-	      po_opt[dacit_max->second.second[pix].roc()] = dacit_max->first;
-	      bestDist[dacit_max->second.second[pix].roc()] = dist;
-	    } 
-	  }
-	}
-      }
-    }
-  }
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    LOG(logDEBUG)<<"opt centring step: po "<<po_opt[rocIds[roc_it]]<<" and scale "<<ps_opt[rocIds[roc_it]]<<", with distance "<<bestDist[rocIds[roc_it]]<<" on ROC "<<(int)rocIds[roc_it];
-  }
-  return po_opt;
-}
-
-map<uint8_t, int> PixTestPhOptimization::StretchPH(map<uint8_t, int> &po_opt, map<uint8_t, int> &ps_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min){
-  //stretching PH curve to exploit the full ADC range, adjusting phscale             
-  int maxPh(0);
-  int minPh(0);
-  bool lowEd=false, upEd=false;
-  int upEd_dist=255, lowEd_dist=255;
-  int safetyMarginUp = fSafetyMarginUp;
-  int safetyMarginLow = fSafetyMarginLow;
-  LOG(logDEBUG)<<"safety margin for stretching set to "<<fSafetyMarginLow<<" (lower edge) and "<<fSafetyMarginUp<<"(upper edge)";
-  int dist = 255;
-  map<uint8_t, int> bestDist;
-  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs();
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    bestDist[rocIds[roc_it]] = 255;
-  }
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin();
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin();
-  while(dacit_max != dacdac_max.end() || dacit_min != dacdac_min.end()){
-    for(unsigned int pix=0; pix < dacit_min->second.second.size() && pix < dacit_max->second.second.size(); pix++){
-      if(dacit_max->first == po_opt[dacit_max->second.second[pix].roc()] && dacit_min->first == po_opt[dacit_min->second.second[pix].roc()]){
-	maxPh=dacit_max->second.second[pix].value();
-	minPh=dacit_min->second.second[pix].value();
-	if(dacit_max->second.second[pix].roc() != dacit_min->second.second[pix].roc()){
-	  LOG(logDEBUG) << "CentrePhRange: ROC ids do not correspond";
-	}
-	lowEd = (minPh > safetyMarginLow);
-	upEd = (maxPh < 255 - safetyMarginUp);
-	upEd_dist = abs(maxPh - (255 - safetyMarginUp));
-	lowEd_dist = abs(minPh - safetyMarginLow);
-	dist = (upEd_dist < lowEd_dist ) ? (upEd_dist) : (lowEd_dist);
-	if(dist < bestDist[dacit_max->second.second[pix].roc()] && lowEd && upEd){
-	  ps_opt[dacit_max->second.second[pix].roc()] = dacit_max->second.first;
-	  bestDist[dacit_max->second.second[pix].roc()]=dist;
-	}
-      }
-    }
-    dacit_max++;
-    dacit_min++;
-  }
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    LOG(logDEBUG)<<"opt final step: po fixed to"<<po_opt[rocIds[roc_it]]<<" and scale adjusted to "<<ps_opt[rocIds[roc_it]]<<", with distance "<<bestDist[rocIds[roc_it]]<<" on ROC "<<(int)rocIds[roc_it];
-  }
-  return ps_opt;
-}
 
 void PixTestPhOptimization::DrawPhMaps(std::map<int, int> &minVcal, std::vector<std::pair<uint8_t, std::pair<int, int> > > &badPixels){
   vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs();
   string name, title;
   //draw PH maps and extract validation distributions from them
-    fApi->_dut->testAllPixels(true);
-    fApi->_dut->maskAllPixels(false);
-    
-    std::vector<pxar::pixel> result_map;
-    map<int, TH2D* > h2_PhMaps;
-    map<int, TH1D* > h1_PhMaps;
-    TH2D* h2_PhMap(0);
-    TH1D* h1_PhMap(0);
-    fApi->setDAC("ctrlreg",4);
-    fApi->setDAC("vcal",255);
-    //pulseheight map at vcal=255
-    result_map = fApi->getPulseheightMap(0,10);
-    //unpacking data from map and filling one histo per ROC
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      name  = Form("PH_mapHiVcal_C%d", rocIds[roc_it]);
-      title = Form("PH_mapHiVcal_C%d", rocIds[roc_it]);
-      h2_PhMap = bookTH2D(name, name, 52, 0., 52., 80, 0., 80.);
-      h2_PhMaps.insert(make_pair(rocIds[roc_it], h2_PhMap));
-      fHistList.push_back(h2_PhMaps[rocIds[roc_it]]);  
-      fHistOptions.insert( make_pair(h2_PhMaps[rocIds[roc_it]], "colz")  ); 
-    }
-    for (unsigned int i = 0; i < result_map.size(); ++i) {
-      h2_PhMaps[ (int) result_map[i].roc() ]->Fill( result_map[i].column(), result_map[i].row(), result_map[i].value());
-    }
-    //adjust z axis range and extract ph distribution
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      h2_PhMaps[ (int) rocIds[roc_it] ]->GetZaxis()->SetRangeUser(h2_PhMaps[ (int) rocIds[roc_it] ]->GetMinimum(), 255. );
-      h1_PhMap = distribution( h2_PhMaps[ (int) rocIds[roc_it] ], 255, 0., 255.);
-      h1_PhMaps.insert( make_pair(rocIds[roc_it], h1_PhMap) );
-      fHistList.push_back(h1_PhMaps[rocIds[roc_it]]);  
-    }
-    
-    //PH map for lower vcal sampling point
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      fApi->setDAC("ctrlreg",0);
-      fApi->setDAC("vcal",minVcal[roc_it]+10, rocIds[roc_it] );
-    }
-    map<int, TH2D* > h2_PhMapsMin;
-    map<int, TH1D* > h1_PhMapsMin;
-    //phmap
-    result_map = fApi->getPulseheightMap(0,10);
-    //unpacking data from map and filling one histo per ROC
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      name  = Form("PH_mapLowVcal_C%d", rocIds[roc_it]);
-      title = Form("PH_mapLowVcal_C%d", rocIds[roc_it]);
-      h2_PhMap = bookTH2D(name, name, 52, 0., 52., 80, 0., 80.);
-      h2_PhMapsMin.insert(make_pair(rocIds[roc_it], h2_PhMap));
-      fHistList.push_back(h2_PhMapsMin[rocIds[roc_it]]);  
-      fHistOptions.insert( make_pair(h2_PhMapsMin[rocIds[roc_it]], "colz")  ); 
-    }
-    for (unsigned int i = 0; i < result_map.size(); ++i) {
-      h2_PhMapsMin[ (int) result_map[i].roc() ]->Fill( result_map[i].column(), result_map[i].row(), result_map[i].value());
-    }
-    //removing blacklisted pixels (bincontent = 0) from histos
-    for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
-      h2_PhMaps[ bad_it->first] ->SetBinContent( h2_PhMaps[ bad_it->first] ->FindFixBin(bad_it->second.first, bad_it->second.second), 0);
-      h2_PhMapsMin[ bad_it->first] ->SetBinContent( h2_PhMapsMin[ bad_it->first] ->FindFixBin(bad_it->second.first, bad_it->second.second), 0);
-    }
-    //adjust z axis range and extract ph distribution
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      name  = Form("PH_distr_LowVcal_C%d", rocIds[roc_it]);
-      title = Form("PH_distr_LowVcal_C%d", rocIds[roc_it]);
-      h2_PhMapsMin[ (int) rocIds[roc_it] ]->GetZaxis()->SetRangeUser(0., h2_PhMapsMin[ (int) rocIds[roc_it] ]->GetMaximum() );
-      h1_PhMap = distribution( h2_PhMapsMin[ (int) rocIds[roc_it] ], 255, 0., 255.);
-      h1_PhMapsMin.insert( make_pair(rocIds[roc_it], h1_PhMap) );
-      fHistList.push_back(h1_PhMapsMin[rocIds[roc_it]]);  
-    }
+  fApi->_dut->testAllPixels(true);
+  fApi->_dut->maskAllPixels(false);
+  
+  std::vector<pxar::pixel> result_map;
+  map<int, TH2D* > h2_PhMaps;
+  map<int, TH1D* > h1_PhMaps;
+  TH2D* h2_PhMap(0);
+  TH1D* h1_PhMap(0);
+  fApi->setDAC("ctrlreg",4);
+  fApi->setDAC("vcal",fVcalMax);
+  //pulseheight map at vcal=100
+  result_map = fApi->getPulseheightMap(0,10);
+  //unpacking data from map and filling one histo per ROC
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    name  = Form("PH_mapHiVcal_C%d", rocIds[roc_it]);
+    title = Form("PH_mapHiVcal_C%d", rocIds[roc_it]);
+    h2_PhMap = bookTH2D(name, name, 52, 0., 52., 80, 0., 80.);
+    h2_PhMaps.insert(make_pair(rocIds[roc_it], h2_PhMap));
+    fHistList.push_back(h2_PhMaps[rocIds[roc_it]]);  
+    fHistOptions.insert( make_pair(h2_PhMaps[rocIds[roc_it]], "colz")  ); 
+  }
+  for (unsigned int i = 0; i < result_map.size(); ++i) {
+    h2_PhMaps[ (int) result_map[i].roc() ]->Fill( result_map[i].column(), result_map[i].row(), result_map[i].value());
+  }
+  
+  //PH map for lower vcal sampling point
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    fApi->setDAC("ctrlreg",0);
+    fApi->setDAC("vcal",minVcal[roc_it]+10, rocIds[roc_it] );
+  }
+  map<int, TH2D* > h2_PhMapsMin;
+  map<int, TH1D* > h1_PhMapsMin;
+  //phmap
+  result_map = fApi->getPulseheightMap(0,10);
+  //unpacking data from map and filling one histo per ROC
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    name  = Form("PH_mapLowVcal_C%d", rocIds[roc_it]);
+    title = Form("PH_mapLowVcal_C%d", rocIds[roc_it]);
+    h2_PhMap = bookTH2D(name, name, 52, 0., 52., 80, 0., 80.);
+    h2_PhMapsMin.insert(make_pair(rocIds[roc_it], h2_PhMap));
+    fHistList.push_back(h2_PhMapsMin[rocIds[roc_it]]);  
+    fHistOptions.insert( make_pair(h2_PhMapsMin[rocIds[roc_it]], "colz")  ); 
+  }
+  for (unsigned int i = 0; i < result_map.size(); ++i) {
+    h2_PhMapsMin[ (int) result_map[i].roc() ]->Fill( result_map[i].column(), result_map[i].row(), result_map[i].value());
+  }
+  
+  
+  //PH map for lower vcal sampling point
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    fApi->setDAC("ctrlreg",0);
+    fApi->setDAC("vcal",50, rocIds[roc_it] );
+  }
+  map<int, TH2D* > h2_PhMaps50;
+  map<int, TH1D* > h1_PhMaps50;
+  //phmap
+  result_map = fApi->getPulseheightMap(0,10);
+  //unpacking data from map and filling one histo per ROC
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    name  = Form("PH_mapVcal50_C%d", rocIds[roc_it]);
+    title = Form("PH_mapVcal50_C%d", rocIds[roc_it]);
+    h2_PhMap = bookTH2D(name, name, 52, 0., 52., 80, 0., 80.);
+    h2_PhMaps50.insert(make_pair(rocIds[roc_it], h2_PhMap));
+    fHistList.push_back(h2_PhMaps50[rocIds[roc_it]]);  
+    fHistOptions.insert( make_pair(h2_PhMaps50[rocIds[roc_it]], "colz")  ); 
+  }
+  for (unsigned int i = 0; i < result_map.size(); ++i) {
+    h2_PhMaps50[ (int) result_map[i].roc() ]->Fill( result_map[i].column(), result_map[i].row(), result_map[i].value());
+  }
+  
+  //removing blacklisted pixels (bincontent = 0) from histos
+  for(std::vector<std::pair<uint8_t, pair<int, int> > >::iterator bad_it = badPixels.begin(); bad_it != badPixels.end(); bad_it++){
+    h2_PhMaps[ bad_it->first] ->SetBinContent( h2_PhMaps[ bad_it->first] ->FindFixBin(bad_it->second.first, bad_it->second.second), 0);
+    h2_PhMapsMin[ bad_it->first] ->SetBinContent( h2_PhMapsMin[ bad_it->first] ->FindFixBin(bad_it->second.first, bad_it->second.second), 0);
+    h2_PhMaps50[ bad_it->first] ->SetBinContent( h2_PhMaps50[ bad_it->first] ->FindFixBin(bad_it->second.first, bad_it->second.second), 0);
+  }
+  
+  //adjust z axis range and extract ph distribution
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    h2_PhMaps[ (int) rocIds[roc_it] ]->GetZaxis()->SetRangeUser(h2_PhMaps[ (int) rocIds[roc_it] ]->GetMinimum(), 255. );
+    h1_PhMap = distribution( h2_PhMaps[ (int) rocIds[roc_it] ], 255, 0., 255.);
+    h1_PhMaps.insert( make_pair(rocIds[roc_it], h1_PhMap) );
+    fHistList.push_back(h1_PhMaps[rocIds[roc_it]]);  
+  }
+  
+  //adjust z axis range and extract ph distribution
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    h2_PhMapsMin[ (int) rocIds[roc_it] ]->GetZaxis()->SetRangeUser(0., h2_PhMapsMin[ (int) rocIds[roc_it] ]->GetMaximum() );
+    h1_PhMap = distribution( h2_PhMapsMin[ (int) rocIds[roc_it] ], 255, 0., 255.);
+    h1_PhMapsMin.insert( make_pair(rocIds[roc_it], h1_PhMap) );
+    fHistList.push_back(h1_PhMapsMin[rocIds[roc_it]]);  
+  }
+  
+  //adjust z axis range and extract ph distribution
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    h2_PhMaps50[ (int) rocIds[roc_it] ]->GetZaxis()->SetRangeUser(0., h2_PhMaps50[ (int) rocIds[roc_it] ]->GetMaximum() );
+    h1_PhMap = distribution( h2_PhMaps50[ (int) rocIds[roc_it] ], 255, 0., 255.);
+    h1_PhMaps50.insert( make_pair(rocIds[roc_it], h1_PhMap) );
+    fHistList.push_back(h1_PhMaps50[rocIds[roc_it]]);  
+  }
+  
 }
 
 void PixTestPhOptimization::DrawPhCurves(map<int, pxar::pixel > &maxpixels, map<int, pxar::pixel > &minpixels, std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt){
   vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs();
   string name, title;
   TH1D *h1(0); 
-    for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-      fApi->setDAC("ctrlreg",4);
-    }
+  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
+    fApi->setDAC("ctrlreg",4);
+  }
   vector<pair<uint8_t, vector<pixel> > > results;
   for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-  //draw PH curve for max and min pixel on every ROC
+    //draw PH curve for max and min pixel on every ROC
     results.clear();
     name  = Form("PH_c%d_r%d_C%d", maxpixels[roc_it].column(), maxpixels[roc_it].row(), rocIds[roc_it]);
     title = Form("PH_c%d_r%d_C%d, phscale = %d, phoffset = %d, maxpixel", maxpixels[roc_it].column(), maxpixels[roc_it].row(), rocIds[roc_it], ps_opt[rocIds[roc_it]], po_opt[rocIds[roc_it]]);
@@ -810,7 +810,6 @@ void PixTestPhOptimization::DrawPhCurves(map<int, pxar::pixel > &maxpixels, map<
     fHistList.push_back(h1);
   }
 }
-
 void PixTestPhOptimization::MaxPhVsDacDac(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max, map<int, pxar::pixel> maxpixels){
   
   fApi->_dut->testAllPixels(false);
@@ -819,7 +818,8 @@ void PixTestPhOptimization::MaxPhVsDacDac(std::vector< std::pair<uint8_t, std::p
     fApi->_dut->testPixel(maxp_it->second.column(),maxp_it->second.row(),true, getIdxFromId(maxp_it->second.roc()));
     fApi->_dut->maskPixel(maxp_it->second.column(),maxp_it->second.row(),false, getIdxFromId(maxp_it->second.roc()));
   } 
-  fApi->setDAC("vcal",255);
+  //sample pulseheight at 35k e-
+  fApi->setDAC("vcal",fVcalMax);
   fApi->setDAC("ctrlreg",4);
   
   //scanning through offset and scale for max pixel (or randpixel)
@@ -834,77 +834,36 @@ void PixTestPhOptimization::MaxPhVsDacDac(std::vector< std::pair<uint8_t, std::p
       ++cnt;
     }
     done = (cnt>5) || done;
-  }
-  //std::map<uint8_t, std::map<std::pair<uint8_t, uint8_t>, pxar::pixel > >  dacdacmax_map;
-  //std::map<std::pair<uint8_t ,uint8_t >, pxar::pixel > tempMap;
-  for(  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin(); dacit_max < dacdac_max.end(); dacit_max+=10){
-    LOG(logDEBUG)<<"size "<<(int)(dacdac_max.end() - dacdac_max.begin())<<"pos "<<(int)(dacdac_max.end() - dacit_max)<<" sizepix "<<(int)dacit_max->second.second.size();
- //   for(int ipix=0; ipix < dacit_max->second.second.size(); ipix++ ){
- //     LOG(logDEBUG)<<"roc "<< (int)dacit_max->second.second[ipix].roc() <<" col "<<(int)dacit_max->second.second[ipix].column() << " row "<<(int)dacit_max->second.second[ipix].row();
- //   }
-  // for(int ipix=0; ipix < dacit_max->second.second.size(); ipix++ ){
-  //   tempMap[ make_pair(dacit_max->first, dacit_max->second.first) ] = dacit_max->second.second.at(ipix);
-  //   dacdacmax_map[dacit_max->second.second[ipix].roc()] = tempMap;
-  //   tempMap.clear();
-  //  }
-  }
-  
-  
+  }  
 }
 
 void PixTestPhOptimization::MinPhVsDacDac(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min, map<int, pxar::pixel> minpixels, std::map<int, int> &minVcal){
-  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs();
+
   fApi->_dut->testAllPixels(false);
   fApi->_dut->maskAllPixels(true);
-  unsigned int NRocs = rocIds.size();
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > dacdac_min_part;
-
   for(std::map<int, pxar::pixel>::iterator minp_it = minpixels.begin(); minp_it != minpixels.end(); minp_it++){
-    for(unsigned int roc_kt = 0; roc_kt < NRocs; roc_kt++){
-      fApi->_dut->setROCEnable(roc_kt, false);
-    }
-    fApi->_dut->setROCEnable(minp_it->first, true);
-    fApi->_dut->testPixel(minp_it->second.column(),minp_it->second.row(),true);
-    fApi->_dut->maskPixel(minp_it->second.column(),minp_it->second.row(),false);
-  
-    fApi->setDAC("ctrlreg",0);
-    fApi->setDAC("vcal",minVcal[minp_it->first]+10, rocIds[minp_it->first]);
+    fApi->_dut->testPixel(minp_it->second.column(),minp_it->second.row(),true, getIdxFromId(minp_it->second.roc()));
+    fApi->_dut->maskPixel(minp_it->second.column(),minp_it->second.row(),false, getIdxFromId(minp_it->second.roc()));
+  }
+
+  fApi->setDAC("ctrlreg",0);
+  for(std::map<int, int>::iterator ivcal = minVcal.begin(); ivcal != minVcal.end(); ivcal++){
+    fApi->setDAC("vcal",minVcal[ivcal->first]+10, getIdxFromId(ivcal->first));
+  }
     
   //scanning through offset and scale for min pixel (or same randpixel)
-    int cnt = 0; 
-    int done = false;
-    while (!done) {
-      try {
-	dacdac_min_part = fApi->getPulseheightVsDACDAC("phoffset",0,255,"phscale",0,255,0,10);
-	done = true;
-      } catch(pxarException &e) {
-	LOG(logCRITICAL) << "pXar execption: "<< e.what(); 
-	++cnt;
+  int cnt = 0; 
+  bool done = false;
+  while (!done) {
+    try {
+      dacdac_min = fApi->getPulseheightVsDACDAC("phoffset",0,255,"phscale",0,255,0,10);
+      done = true;
+    } catch(pxarException &e) {
+      LOG(logCRITICAL) << "pXar execption: "<< e.what(); 
+      ++cnt;
     }
-      done = (cnt>5) || done;
-    }
-    int dacdacsize_old = dacdac_min.size();
-    dacdac_min.resize(dacdac_min.size() + dacdac_min_part.size());
-    for(int idacdacpart = 0; idacdacpart< dacdac_min_part.size(); idacdacpart++){
-      dacdac_min[dacdacsize_old + idacdacpart] = dacdac_min_part[idacdacpart];
-    }
-    dacdac_min_part.clear();
+    done = (cnt>5) || done;
   }
-
-  //  std::map<uint8_t, std::map<std::pair<uint8_t, uint8_t>, pxar::pixel > >  dacdacmin_map;
-  //std::map<std::pair<uint8_t ,uint8_t >, pxar::pixel > tempMap;
-  for(  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin(); dacit_min < dacdac_min.end(); dacit_min+=1000){
-    LOG(logDEBUG)<<"dacdac_min: size "<<(int)(dacdac_min.end() - dacdac_min.begin())<<"pos "<<(int)(dacdac_min.end() - dacit_min)<<" sizepix "<<(int)dacit_min->second.second.size();
-    for(int ipix=0; ipix < dacit_min->second.second.size(); ipix++ ){
-      LOG(logDEBUG)<<"roc "<< (int)dacit_min->second.second[ipix].roc() <<" col "<<(int)dacit_min->second.second[ipix].column() << " row "<<(int)dacit_min->second.second[ipix].row();
-    }
-//   for(int ipix=0; ipix < dacit_min->second.second.size(); ipix++ ){
-//     tempMap[ make_pair(dacit_min->first, dacit_min->second.first) ] = dacit_min->second.second.at(ipix);
-//     dacdacmin_map[dacit_min->second.second[ipix].roc()] = tempMap;
-//     tempMap.clear();
-//    }
-  }
-
 }
 
 void PixTestPhOptimization::SetMinThr(){
@@ -921,74 +880,101 @@ void PixTestPhOptimization::SetMinThr(){
   }
 }
 
+void PixTestPhOptimization::getTH2fromMaps(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min, std::vector<TH2D* > &th2_max, std::vector<TH2D* > &th2_min){
 
-/*map<uint8_t, int> PixTestPhOptimization::InsideRangePH_new(map<uint8_t,int> &po_opt,  std::map<uint8_t, std::map<std::pair<uint8_t, uint8_t>, pxar::pixel > >  dacdacmax_map, std::map<uint8_t, std::map<std::pair<uint8_t, uint8_t>, pxar::pixel > >  dacdacmin_map){
-  //adjusting phscale so that the PH curve is fully inside the ADC range
-  map<uint8_t, int> ps_opt;
-  int maxPh(0);
-  int minPh(0);
-  bool lowEd=false, upEd=false;
-  int upEd_dist=255, lowEd_dist=255;
-  int safetyMargin = 50;
-  int dist = 255;
-  map<uint8_t, int> bestDist;
-  LOG(logDEBUG) << "dacdac at max vcal has size "<<dacdac_max.size()<<endl;
-  LOG(logDEBUG) << "dacdac at min vcal has size "<<dacdac_min.size()<<endl;
-  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    bestDist[rocIds[roc_it]] = 255;
-    LOG(logDEBUG)<<"Bestdist at roc_it "<<roc_it<<" initialized with "<<bestDist[roc_it]<<" "<<bestDist[rocIds[roc_it]];
-    ps_opt[rocIds[roc_it]] = 999;
-  }
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin();
-  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin();
-//  for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
-//    for(int pixit = 0; pixit < dacit_max->second.second.size(); pixit++){
-//      LOG(logDEBUG)<<"dacit_max: pixel "<<(int)dacit_max->second.second[pixit].roc()<<", "<<(int)dacit_max->second.second[pixit].column()<<", "<<(int)dacit_max->second.second[pixit].row()<<", ph offset "<<(int)dacit_max->first<<", ph scale "<<(int)dacit_max->second.first<<", max ph "<<(int)dacit_max->second.second[pixit].value();
-//      LOG(logDEBUG)<<"dacit_min: pixel "<<(int)dacit_min->second.second[pixit].roc()<<", "<<(int)dacit_min->second.second[pixit].column()<<", "<<(int)dacit_min->second.second[pixit].row()<<", ph offset "<<(int)dacit_min->first<<", ph scale "<<(int)dacit_min->second.first<<", min ph "<<(int)dacit_min->second.second[pixit].value();
-//    }
-//    dacit_min++;
-//  }
-  int pixsize_max=0;
-  int pixsize_min=0;
-  LOG(logDEBUG)<<"InsideRange() subtest";
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
-      if(dacit_max->first == po_opt[rocIds[roc_it]]){
-	for(dacit_min = dacdac_min.begin(); dacit_min != dacdac_min.end(); dacit_min++)
-	  if(dacit_min->first == po_opt[rocIds[roc_it]] && dacit_min->second.first == dacit_max->second.first){
-    	    pixsize_max = dacit_max->second.second.size();
-	    pixsize_min = dacit_min->second.second.size();
-    	    for(int pix=0; pix < pixsize_max; pix++){
-	      if(dacit_max->second.second[pix].roc()!=rocIds[roc_it] || dacit_min->second.second[pix].roc()!=rocIds[roc_it]){
-		LOG(logDEBUG)<<"####//// this time roc ids DO NOT match "<<(int)dacit_min->second.second[pix].roc()<<" "<<(int)dacit_max->second.second[pix].roc()<<" "<<(int)rocIds[roc_it]<<" "<<(int)roc_it<<" ////####";
-		continue;
-	      }
-	      LOG(logDEBUG)<<"####//// this time roc ids match "<<(int)rocIds[roc_it]<<" "<<(int)roc_it<<" ////####";
-	      maxPh=dacit_max->second.second[pix].value();
-	      minPh=dacit_min->second.second[pix].value();
-	      if(dacit_max->second.second[pix].roc() != dacit_min->second.second[pix].roc()){
-		LOG(logDEBUG) << "InsideRangePH: ROC ids do not correspond";
-	      }
-	      lowEd = (minPh > safetyMargin);
-	      upEd = (maxPh < 255 - safetyMargin);
-	      lowEd_dist = abs(minPh - safetyMargin);
-	      upEd_dist = abs(maxPh - (255 - safetyMargin));
-	      dist = (upEd_dist > lowEd_dist ) ? (upEd_dist) : (lowEd_dist);
-	      if(dist < bestDist[dacit_max->second.second[pix].roc()] && upEd && lowEd){
-		LOG(logDEBUG)<<"New distance "<<dist<<" is smaller than previous bestDist "<<bestDist[dacit_max->second.second[pix].roc()]<<" and edges are ok, so... ";
-		ps_opt[dacit_max->second.second[pix].roc()] = dacit_max->second.first;
-		bestDist[dacit_max->second.second[pix].roc()]=dist;
-		LOG(logDEBUG)<<"... new bestDist is "<<bestDist[dacit_max->second.second[pix].roc()]<<" for ps_opt = "<<ps_opt[dacit_max->second.second[pix].roc()];
-	      }
-	    }
-	  }
-      }
-    }
+  TH2D* h2 = new TH2D("h2", "h2", 256, 0., 255., 256, 0., 255.);
+  for(unsigned int i=0; i< fApi->_dut->getNEnabledRocs() ; i++){
+    th2_max[i] = (TH2D*)h2->Clone(Form("maxphvsdacdac_th2_C%d", getIdFromIdx(i)));
+    th2_max[i]->SetTitle(Form("max PH phscaleVSphoffset, C%d",  getIdFromIdx(i)));
+    th2_max[i]->GetXaxis()->SetTitle("phscale");
+    th2_max[i]->GetYaxis()->SetTitle("phoffset");
+    th2_min[i] = (TH2D*)h2->Clone(Form("minphvsdacdac_th2_C%d", getIdFromIdx(i)));
+    th2_min[i]->SetTitle(Form("min PH phscaleVSphoffset, C%d",  getIdFromIdx(i)));
+    th2_min[i]->GetXaxis()->SetTitle("phscale");
+    th2_min[i]->GetYaxis()->SetTitle("phoffset");
   }
   
-  for(unsigned int roc_it = 0; roc_it < rocIds.size(); roc_it++){
-    LOG(logDEBUG)<<"opt step 1: po fixed to"<<po_opt[rocIds[roc_it]]<<" and scale adjusted to "<<ps_opt[rocIds[roc_it]]<<" for ROC "<<(int)rocIds[roc_it]<<", with distance "<<bestDist[rocIds[roc_it]];
+  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_max = dacdac_max.begin();
+  for(dacit_max = dacdac_max.begin(); dacit_max != dacdac_max.end(); dacit_max++){
+    for(unsigned int ipix = 0; ipix< dacit_max->second.second.size(); ipix++){
+      th2_max[getIdxFromId(dacit_max->second.second[ipix].roc())]->Fill(dacit_max->second.first, dacit_max->first, dacit_max->second.second[ipix].value());
+    }
+  } 
+  
+  
+  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > >::iterator dacit_min = dacdac_min.begin();
+  for(dacit_min = dacdac_min.begin(); dacit_min != dacdac_min.end(); dacit_min++){
+    for(unsigned int ipix = 0; ipix< dacit_min->second.second.size(); ipix++){
+      th2_min[getIdxFromId(dacit_min->second.second[ipix].roc())]->Fill(dacit_min->second.first, dacit_min->first, dacit_min->second.second[ipix].value());
+    }
+  }   
+}
+
+
+void PixTestPhOptimization::optimiseOnMapsNew(std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt,  std::vector<TH2D* > &th2_max, std::vector<TH2D* > &th2_min, std::vector<TH2D* > &th2_sol){
+  vector<uint8_t> rocIds = fApi->_dut->getEnabledRocIDs(); 
+  TH2D* hmin(0);
+  TH2D* hmax(0);
+  TH2D* hsol = new TH2D("hsol", "hsol", 256, 0., 255., 256, 0., 255.);
+  for(unsigned int i=0; i< fApi->_dut->getNEnabledRocs() ; i++){
+    LOG(logDEBUG)<<"before assigning th2_sol to vector component";
+    th2_sol[i] = (TH2D*)hsol->Clone(Form("solphvsdacdac_th2_C%d", getIdFromIdx(i)));
+    th2_sol[i]->SetTitle(Form("Solution phscaleVSphoffset C%d", getIdFromIdx(i)));
+    th2_sol[i]->GetXaxis()->SetTitle("phscale");
+    th2_sol[i]->GetYaxis()->SetTitle("phoffset");
+    fHistList.push_back(th2_sol[i]);
+    fHistOptions.insert( make_pair(th2_sol[i], "colz" ) ); 
+    LOG(logDEBUG)<<"after assigning th2_sol to vector component, chip"<<getIdFromIdx(i);
   }
-  return ps_opt;
-}*/
+  int goodbinx = 0, goodbiny = 0, goodbinz=0;
+  double maxsol=0.;
+  double maxPH=0.;
+  
+  for(unsigned int iroc = 0; iroc < rocIds.size(); iroc++){
+    maxsol=0.;
+    for(int safetyCorrection = 0; maxsol<1. && safetyCorrection+fSafetyMarginLow<256; safetyCorrection++){
+      LOG(logINFO)<<"safety margin for low PH: adding "<<safetyCorrection<<", margin is now "<<safetyCorrection+fSafetyMarginLow;
+      // hsol->Reset("M");
+      hmin = (TH2D*)th2_min[rocIds[iroc]]->Clone();
+      hmax = (TH2D*)th2_max[rocIds[iroc]]->Clone();
+      maxPH = hmax->GetMaximum();
+      
+      for(int ibinx=1; ibinx < hmax->GetNbinsX()+1; ibinx++){
+	for(int ibiny=1; ibiny < hmax->GetNbinsY()+1; ibiny++){
+	  if(abs(hmax->GetBinContent(ibinx, ibiny) - maxPH + 2) > 1 ){
+	    hmax->SetBinContent(ibinx, ibiny, 0);
+	  }
+	}
+      }
+      
+      for(int ibinx=1; ibinx < hmin->GetNbinsX()+1; ibinx++){
+	for(int ibiny=1; ibiny < hmin->GetNbinsY()+1; ibiny++){
+	  if(abs(hmin->GetBinContent(ibinx, ibiny) - (fSafetyMarginLow+safetyCorrection)) > 1 ){
+	    hmin->SetBinContent(ibinx, ibiny, 0);
+	  }
+	}
+      }
+      
+      for(int ibinx=1; ibinx < hmin->GetNbinsX()+1; ibinx++){
+	for(int ibiny=1; ibiny < hmin->GetNbinsY()+1; ibiny++){
+	  if(hmin->GetBinContent(ibinx, ibiny) != 0 && hmax->GetBinContent(ibinx, ibiny) != 0){
+	    th2_sol[rocIds[iroc]]->SetBinContent(ibinx, ibiny, 1);
+	  }
+	}
+      }
+      maxsol = th2_sol[rocIds[iroc]]->GetMaximum();
+      th2_sol[rocIds[iroc]]->GetBinXYZ(th2_sol[rocIds[iroc]]->GetMaximumBin(), goodbinx, goodbiny, goodbinz);
+      
+    }
+    //po_opt[rocIds[iroc]] = (int)th2_sol[rocIds[iroc]]->GetXaxis()->GetBinCenter(goodbinx);
+    //ps_opt[rocIds[iroc]] = (int)th2_sol[rocIds[iroc]]->GetYaxis()->GetBinCenter(goodbiny);
+    po_opt[rocIds[iroc]] = goodbiny - 1;
+    ps_opt[rocIds[iroc]] = goodbinx - 1;
+  }
+
+  
+  delete hmin;
+  delete hmax;
+  delete hsol;
+
+}

--- a/tests/PixTestPhOptimization.hh
+++ b/tests/PixTestPhOptimization.hh
@@ -19,22 +19,23 @@ public:
   void GetMinPhPixel(std::map<int, pxar::pixel> &minpixel, std::map<int, int> &minVcal, std::vector<std::pair<uint8_t, std::pair<int, int> > > &badPixels);
   void MaxPhVsDacDac(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max, std::map<int, pxar::pixel> maxpixels);
   void MinPhVsDacDac(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min, std::map<int, pxar::pixel> minpixels, std::map<int, int> &minVcal);
-  std::map<uint8_t, int> InsideRangePH(std::map<uint8_t,int> &po_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min);
-  std::map<uint8_t, int> CentrePhRange(std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min);
-  std::map<uint8_t, int> StretchPH(std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt,  std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min);
   void DrawPhMaps(std::map<int, int> &minVcal, std::vector<std::pair<uint8_t, std::pair<int, int> > > &badPixels);
   void DrawPhCurves(std::map<int, pxar::pixel > &maxpixels, std::map<int, pxar::pixel > &minpixels, std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt);
+
+  void optimiseOnMapsNew(std::map<uint8_t, int> &po_opt, std::map<uint8_t, int> &ps_opt,  std::vector<TH2D* > &th2_max, std::vector<TH2D* > &th2_min, std::vector<TH2D* > &th2_sol);
+
+  void getTH2fromMaps(std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_max,   std::vector< std::pair<uint8_t, std::pair<uint8_t, std::vector<pxar::pixel> > > > &dacdac_min, std::vector<TH2D* > &th2_max, std::vector<TH2D* > &th2_min);
+
+
   void doTest(); 
 
 private:
 
   int         fParNtrig; 
-  std::string fParDAC; 
-  int         fParDacVal;
-  bool        fFlagSinglePix;
-  int         fSafetyMarginUp;
   int         fSafetyMarginLow;
   int         fMinThr;
+  double      fQuantMax;
+  int         fVcalMax;
 
   ClassDef(PixTestPhOptimization, 1)
 

--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -157,7 +157,7 @@ void PixTestPretest::doTest() {
   h1->Draw(getHistOption(h1).c_str());
   PixTest::update(); 
 
-  //setTimings();
+  setTimings();
     
   findWorkingPixel();
   h1 = (*fDisplayedHist); 
@@ -371,6 +371,7 @@ void PixTestPretest::setTimings() {
   
   banner(Form("PixTestPreTest::setTimings()"));
 
+  TLogLevel UserReportingLevel = Log::ReportingLevel();
   int nTBMs = fApi->_dut->getNTbms();
   uint16_t period = 300;
 
@@ -378,9 +379,23 @@ void PixTestPretest::setTimings() {
     LOG(logINFO) << "Timing test not needed for single ROC.";
     return;
   }
+
+  bool GoodDelaySettings = false;
+  for (int itry = 0; itry < 3 && !GoodDelaySettings; itry++) {
+    LOG(logDEBUG) << "Testing Timing: Attempt #" << itry+1;
+    fApi->daqStart();
+    fApi->daqTrigger(fParNtrig, period);
+    vector<Event> daqEv = fApi->daqGetEventBuffer();
+    fApi->daqStop();
+    statistics results = fApi->getStatistics();
+    int NEvents = (results.info_events_empty()+results.info_events_valid())/nTBMs;
+    if (results.errors()==0 && NEvents==fParNtrig) GoodDelaySettings = true;
+    if (Log::ReportingLevel() >= logDEBUG) results.dump();
+  }
+
+  if (GoodDelaySettings) banner("Default timings are good. No timing scan needed.");
   
   // Loop through all possible TBM Phases settings.
-  bool GoodDelaySettings = false;
   for (int pll160 = 0; pll160 < 8 && !GoodDelaySettings; pll160++) {
     for (int pll400 = 0; pll400 < 8 && !GoodDelaySettings; pll400++) {
       //Apply TBM Phase Settings
@@ -393,7 +408,7 @@ void PixTestPretest::setTimings() {
       for (int iROCDelay = 0; iROCDelay < 6 && !GoodDelaySettings; iROCDelay++) {
         //Apply ROC Delays
         int ROCDelay = ROCDelays[iROCDelay];
-        unsigned char ROCPhase = (1<<6) | (ROCDelay<<3) | ROCDelay; //Disable token delay, enable header/trailer delay, and set the ROC delays to the same values
+        uint8_t ROCPhase = (1<<6) | (ROCDelay<<3) | ROCDelay; //Disable token delay, enable header/trailer delay, and set the ROC delays to the same values
         LOG(logDEBUG) << "Testing ROC Phase: " << bitset<8>(ROCPhase).to_string();
         for (int itbm=0; itbm<nTBMs; itbm++) fApi->setTbmReg("basea", ROCPhase, itbm); //Set ROC Phases
 
@@ -402,6 +417,7 @@ void PixTestPretest::setTimings() {
         fApi->daqTrigger(fParNtrig, period); //Read in fParNtrig events and throw them away, first event is generally bad.
         vector<rawEvent> daqRawEv = fApi->daqGetRawEventBuffer();
         for (size_t iEvent=0; iEvent<daqRawEv.size(); iEvent++) LOG(logDEBUG) << "Event: " << daqRawEv[iEvent];
+        Log::ReportingLevel() = Log::FromString("QUIET");
         vector<Event> daqEv;
         for (int interation=0; interation < fIterations; interation++) {
           fApi->daqTrigger(fParNtrig, period);
@@ -410,6 +426,7 @@ void PixTestPretest::setTimings() {
         fApi->daqStop();
         statistics results = fApi->getStatistics();
         int NEvents = (results.info_events_empty()+results.info_events_valid())/nTBMs;
+        Log::ReportingLevel() = UserReportingLevel;
         LOG(logDEBUG) << "Number of Errors: " << results.errors();
         LOG(logDEBUG) << "Number of Events: " << NEvents;
         if (Log::ReportingLevel() >= logDEBUG) results.dump();

--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -157,7 +157,7 @@ void PixTestPretest::doTest() {
   h1->Draw(getHistOption(h1).c_str());
   PixTest::update(); 
 
-  setTimings();
+  //setTimings();
     
   findWorkingPixel();
   h1 = (*fDisplayedHist); 


### PR DESCRIPTION
PhOptimization test reworked. Main features are:
- optimisation of PH performed against a given charge of saturation, which can be defined by the user
- fraction of ROC pixels running in PH saturation before the set charge also tunable by the user
- extreme behaviour pixel choice protected against outliers and preferably done avoiding ROC edges
- additional figures of merit of the optimisation
- iterative search of optimal (phoffset,phscale) pair
- compatible with older ROC versions, with different PH DACs 

Tested on 4 modules with digv21respin ROCs and on 1 with dig2 ROCs.