### PR TITLE
Fix Pretest Timing Test for TBM09

### DIFF
--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -372,7 +372,7 @@ void PixTestPretest::setTimings() {
   banner(Form("PixTestPreTest::setTimings()"));
 
   TLogLevel UserReportingLevel = Log::ReportingLevel();
-  int nTBMs = fApi->_dut->getNTbms();
+  int nTBMs = (fApi->_dut->getTbmType() == "tbm09") ? 4 : 2;
   uint16_t period = 300;
 
   if (nTBMs==0) {


### PR DESCRIPTION
This is a fix for the pretest settimings test for TBM09. This issue was raised by Vittorio in issue #344.