### PR TITLE
Fixed problem for single ROC in settimings pretest

### DIFF
--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -372,13 +372,15 @@ void PixTestPretest::setTimings() {
   banner(Form("PixTestPreTest::setTimings()"));
 
   TLogLevel UserReportingLevel = Log::ReportingLevel();
-  int nTBMs = (fApi->_dut->getTbmType() == "tbm09") ? 4 : 2;
+  int nTBMs = fApi->_dut->getNTbms();
   uint16_t period = 300;
 
   if (nTBMs==0) {
     LOG(logINFO) << "Timing test not needed for single ROC.";
     return;
   }
+
+  if (fApi->_dut->getTbmType() == "tbm09") nTBMs = 4;
 
   bool GoodDelaySettings = false;
   for (int itry = 0; itry < 3 && !GoodDelaySettings; itry++) {


### PR DESCRIPTION
After adding a fix to the set timing pre-test for TBM09, #345 broke it for a single ROC. This fixes that fix. I still think there maybe be a problem with the timing scan for TBM09 if the default timings don't work. But since I don't have a TBM09, I'm not going to worry about it.