### PR TITLE
Masked pixels during timing tests

### DIFF
--- a/tests/PixTestPretest.cc
+++ b/tests/PixTestPretest.cc
@@ -370,6 +370,8 @@ void PixTestPretest::setTimings() {
   timer t;
   
   banner(Form("PixTestPreTest::setTimings()"));
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
 
   TLogLevel UserReportingLevel = Log::ReportingLevel();
   int nTBMs = fApi->_dut->getNTbms();

--- a/tests/PixTestTiming.cc
+++ b/tests/PixTestTiming.cc
@@ -230,6 +230,9 @@ void PixTestTiming::PhaseScan() {
   fDirectory->cd();
   PixTest::update();
 
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
+  
   //Make histograms
   TH2D *h1(0);
   TH2D *h2(0);
@@ -442,6 +445,9 @@ void PixTestTiming::TBMPhaseScan() {
   // Start test timer
   timer t;
 
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
+
   banner(Form("PixTestTiming::TBMPhaseScan()"));
   cacheTBMDacs();
 
@@ -494,6 +500,9 @@ void PixTestTiming::ROCDelayScan() {
 
   // Start test timer
   timer t;
+
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
 
   banner(Form("PixTestTiming::ROCDelayScan()"));
   cacheTBMDacs();
@@ -555,6 +564,9 @@ void PixTestTiming::TimingTest() {
   // Start test timer
   timer t;
 
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
+
   banner(Form("PixTestTiming::TimingTest()"));
 
   int nTBMs = fApi->_dut->getNTbms();
@@ -581,6 +593,9 @@ void PixTestTiming::LevelScan() {
 
   // Start test timer
   timer t;
+
+  fApi->_dut->testAllPixels(false);
+  fApi->_dut->maskAllPixels(true);
 
   fDirectory->cd();
   PixTest::update();


### PR DESCRIPTION
I masked the pixels during the timing test because it was causing various problems where the dut was not being initialized correctly. All timing tests should work once pXar is started.