### PR TITLE
Retry fetching data from channels

### DIFF
--- a/core/api/exceptions.h
+++ b/core/api/exceptions.h
@@ -73,6 +73,15 @@ namespace pxar {
   DataNoEvent(const std::string& what_arg) : DataException(what_arg) {}
   };
 
+  /** This exception class is used whenever multiple DAQ channels are active and
+   *  there is a mismatch in event number across the channels (i.e. channel 0
+   *  still returns one event but channel 1 is already drained
+   */
+  class DataChannelMismatch : public DataException {
+  public:
+  DataChannelMismatch(const std::string& what_arg) : DataException(what_arg) {}
+  };
+
   /**  This exception class is used when the DAQ readout is incomplete (missing events).
    */
   class DataMissingEvent : public DataException {


### PR DESCRIPTION
This fixes a problem with reading single events from multiple DAQ channels at high rate while the DAQ is running. With the previous code it could happen that Channel 0 already contained the next event while the event in Channel 1 or higher was still being processed by the DESER400 (it could be significantly longer with more pixel hits).

The new code now takes Channel 0 as benchmark. The following scenarios are possible:
 * No new event in Channel 0: throw `DataNoEvent` exception, user could will call `daqGetEvent()` again later
 * New event in Channel 0: now we expect a event in every active channel! Two possibilities:
    * All channels contain a new event: return it.
    * One channel lacks a new event: we retry reading. This will initiate another USB call with ~1msec latency. After this we really expect the event to be there. If there is still no new event a `DataChannelMismatch` exception is thrown: one of the channels didn't detect the expected event that others have successfully recorded.

This prevents from returning half events where only some of the channels have been successfully read.

Currently this does not change the `daqGetEventBuffer()` and `daqGetRawEventBuffer()` functions which are usually called when triggers are halted. However, one could think about adapting the same scheme in these functions too.

In addition, this PR adds a convenient latency scan for the python command line. Just run it, it will scan settings for the DTB trigger latency for highest hit yield.