### PR TITLE
Fixing open issue and improving the separation cut

### DIFF
--- a/tests/PixTestBB2Map.hh
+++ b/tests/PixTestBB2Map.hh
@@ -13,6 +13,7 @@ public:
   void setToolTips();
 
   void doTest(); 
+  double getBB2MapCut(TH1D *hPlSizePerRoc);
   void setVana();
   void setVthrCompCalDelForCals();
 


### PR DESCRIPTION
Dear Urs,

please find in this commit the fix of the open issue of the PixTestBB2Map.cc 
the try and catch condition is included - now it is around the line 204.

Also improvement on the separation cut value is performed. Now the cut for the plateau size is derived for each roc (using the routine getBB2MapCut -at the end of the code-). 

Please let me know if this implementation is ok, or if I have to check once more,
Thanks for your attention,
Cheers,

Andrea