### PR TITLE
Add NTP handling and prepare for Layer1

### DIFF
--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -186,6 +186,10 @@ bool pxarCore::initDUT(uint8_t hubid,
     // Prepare a new TBM configuration of the given type:
     tbmConfig newtbm(stringToDeviceCode(tbmtype));
 
+    // Check if this is core alpha or beta and store it:
+    if((tbmIt - tbmDACs.begin())%2 == 0) { newtbm.core = 0xE0; } // alpha core
+    else { newtbm.core = 0xF0; } // beta core
+
     // Loop over all the DAC settings supplied and fill them into the TBM dacs
     for(std::vector<std::pair<std::string,uint8_t> >::iterator dacIt = (*tbmIt).begin(); dacIt != (*tbmIt).end(); ++dacIt) {
      
@@ -209,10 +213,6 @@ bool pxarCore::initDUT(uint8_t hubid,
 	continue;
       }
 
-      // Check if this is fore core alpha or beta:
-      if((tbmIt - tbmDACs.begin())%2 == 0) { newtbm.core = 0xE0; } // alpha core
-      else { newtbm.core = 0xF0; } // beta core
-      
       std::pair<std::map<uint8_t,uint8_t>::iterator,bool> ret;
       ret = newtbm.dacs.insert( std::make_pair(tbmregister,value) );
       if(ret.second == false) {
@@ -673,9 +673,6 @@ bool pxarCore::setTbmReg(std::string regName, uint8_t regValue, uint8_t tbmid) {
   std::pair<std::map<uint8_t,uint8_t>::iterator,bool> ret;
   if(_dut->tbm.size() > static_cast<size_t>(tbmid)) {
     // Set the register only in the given TBM (even if that is disabled!)
-    
-    // Get the core (alpha/beta) from one of the registers:
-    _register |= _dut->tbm.at(tbmid).dacs.begin()->first&0xF0;
     
     // Update the DUT register Value:
     ret = _dut->tbm.at(tbmid).dacs.insert(std::make_pair(_register,regValue));

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -359,7 +359,7 @@ bool pxarCore::programDUT() {
   std::vector<tbmConfig> enabledTbms = _dut->getEnabledTbms();
   if(!enabledTbms.empty()) {LOG(logDEBUGAPI) << "Programming TBMs...";}
   for (std::vector<tbmConfig>::iterator tbmit = enabledTbms.begin(); tbmit != enabledTbms.end(); ++tbmit){
-    _hal->initTBMCore((*tbmit).type,(*tbmit).dacs,(*tbmit).tokenchains,(*tbmit).notokenpass);
+    _hal->initTBMCore((*tbmit));
   }
 
   std::vector<rocConfig> enabledRocs = _dut->getEnabledRocs();

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -183,15 +183,8 @@ bool pxarCore::initDUT(uint8_t hubid,
 
     LOG(logDEBUGAPI) << "Processing TBM Core " << static_cast<int>(tbmIt - tbmDACs.begin());
 
-    // Set the TBM type (get value from dictionary)
-    uint8_t type = stringToDeviceCode(tbmtype);
-    if(type == 0x0) {
-      LOG(logCRITICAL) << "Invalid TBM type \"" << tbmtype << "\"";
-      throw InvalidConfig("Invalid TBM type.");
-    }
-
     // Prepare a new TBM configuration of the given type:
-    tbmConfig newtbm(type);
+    tbmConfig newtbm(stringToDeviceCode(tbmtype));
 
     // Loop over all the DAC settings supplied and fill them into the TBM dacs
     for(std::vector<std::pair<std::string,uint8_t> >::iterator dacIt = (*tbmIt).begin(); dacIt != (*tbmIt).end(); ++dacIt) {

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -694,11 +694,10 @@ bool pxarCore::setTbmReg(std::string regName, uint8_t regValue, uint8_t tbmid) {
       LOG(logDEBUGAPI) << "Register \"" << regName << "\" (" << std::hex << static_cast<int>(_register) << std::dec << ") updated with value " << static_cast<int>(regValue);
     }
     
-    _hal->tbmSetReg(_register,regValue);
-
-    // Set no token pass if it is enabled:
-    _dut->tbm.at(tbmid).notokenpass = (regName == "base0") && (regValue & 0x40);
-    _hal->tbmSetNoTokenPass(tbmid, (regName == "base0") && (regValue & 0x40));
+    _hal->tbmSetReg(_dut->tbm.at(tbmid).hubid,_dut->tbm.at(tbmid).core | _register,regValue);
+    
+    // update HAL no token pass setting:
+    _hal->tbmSetNoTokenPass(tbmid,_dut->tbm.at(tbmid).tokenchains.size(),_dut->tbm.at(tbmid).NoTokenPass());
   }
   else {
     LOG(logERROR) << "TBM " << tbmid << " is not existing in the DUT!";

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -1628,14 +1628,8 @@ std::vector<Event*> pxarCore::expandLoop(HalMemFnPixelSerial pixelfn, HalMemFnPi
     }
   } // single roc fnc
 
-  // check that we ended up with data
-  if (data.empty()){
-    LOG(logCRITICAL) << "NO DATA FROM TEST FUNCTION -- are any TBMs/ROCs/PIXs enabled?!";
-    // Mask device, clear leftover calibrate signals:
-    MaskAndTrim(false);
-    SetCalibrateBits(false);
-    return data;
-  }
+  // check that we ended up with data, otherwise print an error:
+  if (data.empty()){ LOG(logCRITICAL) << "NO DATA FROM TEST FUNCTION -- are any TBMs/ROCs/PIXs enabled?!"; }
   
   // Test is over, mask the whole device again and clear leftover calibrate signals:
   MaskAndTrim(false);

--- a/core/api/api.h
+++ b/core/api/api.h
@@ -248,7 +248,7 @@ namespace pxar {
      *
      *  In case of USB communication problems, pxar::UsbConnectionError is thrown.
      */
-    bool initDUT(uint8_t hubId,
+    bool initDUT(std::vector<uint8_t> hubIds,
 		 std::string tbmtype, 
 		 std::vector<std::vector<std::pair<std::string,uint8_t> > > tbmDACs,
 		 std::string roctype,
@@ -260,6 +260,31 @@ namespace pxar {
      *
      *  As above, but automatically assumes consecutively numbered I2C addresses for
      *  all attached ROCs, starting from zero.
+     */
+    bool initDUT(std::vector<uint8_t> hubids,
+		 std::string tbmtype, 
+		 std::vector<std::vector<std::pair<std::string,uint8_t> > > tbmDACs,
+		 std::string roctype,
+		 std::vector<std::vector<std::pair<std::string,uint8_t> > > rocDACs,
+		 std::vector<std::vector<pixelConfig> > rocPixels);
+
+    /** Alternative initializer method for the DUT (attached devices).
+     *
+     *  As above, but only accepts one hub id for a single physical TBM
+     */
+    bool initDUT(uint8_t hubid,
+		 std::string tbmtype, 
+		 std::vector<std::vector<std::pair<std::string,uint8_t> > > tbmDACs,
+		 std::string roctype,
+		 std::vector<std::vector<std::pair<std::string,uint8_t> > > rocDACs,
+		 std::vector<std::vector<pixelConfig> > rocPixels,
+		 std::vector<uint8_t> rocI2Cs);
+
+    /** Alternative initializer method for the DUT (attached devices).
+     *
+     *  As above, but automatically assumes consecutively numbered I2C addresses for
+     *  all attached ROCs, starting from zero and only accepts one hub id for a
+     *  single physical TBM.
      */
     bool initDUT(uint8_t hubid,
 		 std::string tbmtype, 

--- a/core/api/datatypes.cc
+++ b/core/api/datatypes.cc
@@ -209,4 +209,14 @@ namespace pxar {
     return lhs;
   }
 
+  tbmConfig::tbmConfig(uint8_t tbmtype) : dacs(), type(tbmtype), hubid(31), core(0xE0), tokenchains(), enable(true) {
+    LOG(logCRITICAL) << "Invalid TBM type \"" << tbmtype << "\"";
+    throw InvalidConfig("Invalid TBM type.");
+      
+    // Standard setup for token chain lengths:
+    // Four ROCs per stream for dual-400MHz, eight ROCs for single-400MHz readout:
+    if(type >= TBM_09) { for(size_t i = 0; i < 2; i++) tokenchains.push_back(4); }
+    else if(type >= TBM_08) { tokenchains.push_back(8); }
+  }
+
 } // namespace pxar

--- a/core/api/datatypes.cc
+++ b/core/api/datatypes.cc
@@ -210,9 +210,12 @@ namespace pxar {
   }
 
   tbmConfig::tbmConfig(uint8_t tbmtype) : dacs(), type(tbmtype), hubid(31), core(0xE0), tokenchains(), enable(true) {
-    LOG(logCRITICAL) << "Invalid TBM type \"" << tbmtype << "\"";
-    throw InvalidConfig("Invalid TBM type.");
-      
+
+    if(tbmtype == 0x0) {
+      LOG(logCRITICAL) << "Invalid TBM type \"" << tbmtype << "\"";
+      throw InvalidConfig("Invalid TBM type.");
+    }
+    
     // Standard setup for token chain lengths:
     // Four ROCs per stream for dual-400MHz, eight ROCs for single-400MHz readout:
     if(type >= TBM_09) { for(size_t i = 0; i < 2; i++) tokenchains.push_back(4); }

--- a/core/api/datatypes.h
+++ b/core/api/datatypes.h
@@ -416,13 +416,7 @@ namespace pxar {
    */
   class DLLEXPORT tbmConfig {
   public:
-  tbmConfig(uint8_t tbmtype) : dacs(), type(tbmtype), hubid(31), core(0xE0), tokenchains(), enable(true) {
-      // Standard setup for token chain lengths:
-      // Four ROCs per stream for dual-400MHz, eight ROCs for single-400MHz readout:
-      if(type >= TBM_09) { for(size_t i = 0; i < 2; i++) tokenchains.push_back(4); }
-      else if(type >= TBM_08) { tokenchains.push_back(8); }
-    }
-    
+    tbmConfig(uint8_t tbmtype);
     std::map< uint8_t,uint8_t > dacs;
     uint8_t type;
     uint8_t hubid;
@@ -432,7 +426,6 @@ namespace pxar {
 
     // Check token pass setting:
     bool NoTokenPass() { return (dacs[0x00]&0x40); };
-    
     // Return readable name of the core:
     std::string corename() { return ((core&0x10) ? "Beta" : "Alpha"); };
   };

--- a/core/api/datatypes.h
+++ b/core/api/datatypes.h
@@ -23,6 +23,8 @@ typedef unsigned char uint8_t;
 #include <limits>
 #include <cmath>
 
+#include "constants.h"
+
 namespace pxar {
 
   /** Class for storing decoded pixel readout data
@@ -414,12 +416,25 @@ namespace pxar {
    */
   class DLLEXPORT tbmConfig {
   public:
-  tbmConfig() : dacs(), type(0), tokenchains(), notokenpass(false), enable(true) {}
+  tbmConfig(uint8_t tbmtype) : dacs(), type(tbmtype), hubid(31), core(0xE0), tokenchains(), enable(true) {
+      // Standard setup for token chain lengths:
+      // Four ROCs per stream for dual-400MHz, eight ROCs for single-400MHz readout:
+      if(type >= TBM_09) { for(size_t i = 0; i < 2; i++) tokenchains.push_back(4); }
+      else if(type >= TBM_08) { tokenchains.push_back(8); }
+    }
+    
     std::map< uint8_t,uint8_t > dacs;
     uint8_t type;
+    uint8_t hubid;
+    uint8_t core;
     std::vector<uint8_t> tokenchains;
-    bool notokenpass;
     bool enable;
+
+    // Check token pass setting:
+    bool NoTokenPass() { return (dacs[0x00]&0x40); };
+    
+    // Return readable name of the core:
+    std::string corename() { return ((core&0x10) ? "Beta" : "Alpha"); };
   };
 
   /** Class for statistics on event and pixel decoding

--- a/core/decoder/datapipe.h
+++ b/core/decoder/datapipe.h
@@ -27,7 +27,6 @@ namespace pxar {
     virtual uint8_t ReadChannel() = 0;
     virtual uint8_t ReadTokenChainLength() = 0;
     virtual uint8_t ReadTokenChainOffset() = 0;
-    virtual uint8_t ReadDefaultTokenChainLength() = 0;
     virtual uint8_t ReadEnvelopeType() = 0;
     virtual uint8_t ReadDeviceType() = 0;
   public:
@@ -47,7 +46,6 @@ namespace pxar {
     uint8_t ReadChannel() { throw dpNotConnected(); }
     uint8_t ReadTokenChainLength() { throw dpNotConnected(); }
     uint8_t ReadTokenChainOffset() { throw dpNotConnected(); }
-    uint8_t ReadDefaultTokenChainLength() { throw dpNotConnected(); }
     uint8_t ReadEnvelopeType() { throw dpNotConnected(); }
     uint8_t ReadDeviceType() { throw dpNotConnected(); }
     template <class TO> friend class dataSink;
@@ -68,7 +66,6 @@ namespace pxar {
     uint8_t GetChannel() { return src->ReadChannel(); }
     uint8_t GetTokenChainLength() { return src->ReadTokenChainLength(); }
     uint8_t GetTokenChainOffset() { return src->ReadTokenChainOffset(); }
-    uint8_t GetDefaultTokenChainLength() { return src->ReadDefaultTokenChainLength(); }
     uint8_t GetEnvelopeType() { return src->ReadEnvelopeType(); }
     uint8_t GetDeviceType() { return src->ReadDeviceType(); }
     void GetAll() { while (true) Get(); }
@@ -116,7 +113,6 @@ namespace pxar {
     uint8_t ReadChannel() { return GetChannel(); }
     uint8_t ReadTokenChainLength() { return GetTokenChainLength(); }
     uint8_t ReadTokenChainOffset() { return GetTokenChainOffset(); }
-    uint8_t ReadDefaultTokenChainLength() { return GetDefaultTokenChainLength(); }
     uint8_t ReadEnvelopeType() { return GetEnvelopeType(); }
     uint8_t ReadDeviceType() { return GetDeviceType(); }
 
@@ -140,7 +136,6 @@ namespace pxar {
     uint8_t ReadChannel() { return GetChannel(); }
     uint8_t ReadTokenChainLength() { return GetTokenChainLength(); }
     uint8_t ReadTokenChainOffset() { return GetTokenChainOffset(); }
-    uint8_t ReadDefaultTokenChainLength() { return GetDefaultTokenChainLength(); }
     uint8_t ReadEnvelopeType() { return GetEnvelopeType(); }
     uint8_t ReadDeviceType() { return GetDeviceType(); }
   public:
@@ -155,7 +150,6 @@ namespace pxar {
     uint8_t ReadChannel() { return GetChannel(); }
     uint8_t ReadTokenChainLength() { return GetTokenChainLength(); }
     uint8_t ReadTokenChainOffset() { return GetTokenChainOffset(); }
-    uint8_t ReadDefaultTokenChainLength() { return GetDefaultTokenChainLength(); }
     uint8_t ReadEnvelopeType() { return GetEnvelopeType(); }
     uint8_t ReadDeviceType() { return GetDeviceType(); }
 

--- a/core/decoder/datasource_evt.h
+++ b/core/decoder/datasource_evt.h
@@ -12,9 +12,8 @@ namespace pxar {
   class evtSource : public dataSource<uint16_t> {
     // --- Control/state
     uint8_t channel;
-    std::vector<uint8_t> chainlength;
+    uint8_t chainlength;
     uint8_t chainlengthOffset;
-    uint8_t defaultChainlength;
     uint8_t envelopetype;
     uint8_t devicetype;
 
@@ -40,15 +39,11 @@ namespace pxar {
     }
     uint8_t ReadTokenChainLength() {
       if(!connected) throw dpNotConnected();
-      return chainlength.at(channel);
+      return chainlength;
     }
     uint8_t ReadTokenChainOffset() {
       if(!connected) throw dpNotConnected();
       return chainlengthOffset;
-    }
-    uint8_t ReadDefaultTokenChainLength() {
-      if(!connected) throw dpNotConnected();
-      return defaultChainlength;
     }
     uint8_t ReadEnvelopeType() {
       if(!connected) throw dpNotConnected();
@@ -59,12 +54,13 @@ namespace pxar {
       return devicetype;
     }
   public:
-  evtSource(uint8_t daqchannel, const std::vector<uint8_t> &tokenChainLength, uint8_t tbmtype, uint8_t roctype)
-    : channel(daqchannel), chainlength(tokenChainLength), chainlengthOffset(0), defaultChainlength(8), envelopetype(tbmtype), devicetype(roctype), lastSample(0x4000), pos(0), connected(true) {
+  evtSource(uint8_t daqchannel, uint8_t tokenChainLength, uint8_t offset, uint8_t tbmtype, uint8_t roctype)
+    : channel(daqchannel), chainlength(tokenChainLength), chainlengthOffset(offset), envelopetype(tbmtype), devicetype(roctype), lastSample(0x4000), pos(0), connected(true) {
       LOG(logDEBUGPIPES) << "New evtSource instantiated with properties:";
       LOG(logDEBUGPIPES) << "-------------------------";
       LOG(logDEBUGPIPES) << "Channel " << static_cast<int>(channel)
-			 << " (" << static_cast<int>(chainlength.at(channel)) << " ROCs)"
+			 << " (" << static_cast<int>(chainlength) << " ROCs, "
+			 << static_cast<int>(chainlengthOffset) << "-" << static_cast<int>(chainlengthOffset+chainlength)<< ")"
 			 << (envelopetype == TBM_NONE ? " DESER160 " : (envelopetype == TBM_EMU ? " SOFTTBM " : " DESER400 "));
     }
   evtSource() : connected(false) {};

--- a/core/emulator/rpc_calls.cpp
+++ b/core/emulator/rpc_calls.cpp
@@ -326,9 +326,9 @@ uint32_t CTestboard::Daq_Open(uint32_t buffersize, uint8_t channel) {
   if(channel > daq_buffer.size()) return 0;
   
   // Reserve some memory (not necessary but nice...)
+  // Dividing by 2 since we're talking abour 16bit words here, not bytes:
   daq_buffer.at(channel).reserve(buffersize/2);
-
-  return daq_buffer.at(channel).capacity();
+  return daq_buffer.at(channel).capacity()*2;
 }
 
 void CTestboard::Daq_Close(uint8_t channel) {

--- a/core/hal/datasource_dtb.cc
+++ b/core/hal/datasource_dtb.cc
@@ -20,7 +20,8 @@ namespace pxar {
 
     LOG(logDEBUGPIPES) << "-------------------------";
     LOG(logDEBUGPIPES) << "Channel " << static_cast<int>(channel)
-		       << " (" << static_cast<int>(chainlength.at(channel)) << " ROCs)"
+		       << " (" << static_cast<int>(chainlength) << " ROCs, "
+		       << static_cast<int>(chainlengthOffset) << "-" << static_cast<int>(chainlengthOffset+chainlength-1)<< ")"
 		       << (envelopetype == TBM_NONE ? " DESER160 " : (envelopetype == TBM_EMU ? " SOFTTBM " : " DESER400 "));
     LOG(logDEBUGPIPES) << "Remaining " << static_cast<int>(dtbRemainingSize);
     LOG(logDEBUGPIPES) << "-------------------------";

--- a/core/hal/datasource_dtb.h
+++ b/core/hal/datasource_dtb.h
@@ -14,9 +14,8 @@ namespace pxar {
     // --- DTB control/state
     CTestboard * tb;
     uint8_t channel;
-    std::vector<uint8_t> chainlength;
+    uint8_t chainlength;
     uint8_t chainlengthOffset;
-    uint8_t defaultChainlength;
     uint32_t dtbRemainingSize;
     uint8_t  dtbState;
     bool connected;
@@ -44,15 +43,11 @@ namespace pxar {
     }
     uint8_t ReadTokenChainLength() {
       if(!connected) throw dpNotConnected();
-      return chainlength.at(channel);
+      return chainlength;
     }
     uint8_t ReadTokenChainOffset() {
       if(!connected) throw dpNotConnected();
       return chainlengthOffset;
-    }
-    uint8_t ReadDefaultTokenChainLength() {
-      if(!connected) throw dpNotConnected();
-      return defaultChainlength;
     }
     uint8_t ReadEnvelopeType() {
       if(!connected) throw dpNotConnected();
@@ -63,13 +58,8 @@ namespace pxar {
       return devicetype;
     }
   public:
-  dtbSource(CTestboard * src, uint8_t daqchannel, const std::vector<uint8_t> &tokenChainLength, uint8_t tbmtype, uint8_t roctype, bool endlessStream)
-    : stopAtEmptyData(endlessStream), tb(src), channel(daqchannel), chainlength(tokenChainLength), chainlengthOffset(0), defaultChainlength(8), connected(true), envelopetype(tbmtype), devicetype(roctype), lastSample(0x4000), pos(0) {
-      for (unsigned i = 0; i < channel; i++)
-        chainlengthOffset += chainlength.at(i);
-      if (tbmtype >= TBM_09)
-        defaultChainlength = 4;
-    }
+  dtbSource(CTestboard * src, uint8_t daqchannel, uint8_t tokenChainLength, uint8_t offset, uint8_t tbmtype, uint8_t roctype, bool endlessStream)
+    : stopAtEmptyData(endlessStream), tb(src), channel(daqchannel), chainlength(tokenChainLength), chainlengthOffset(offset), connected(true), envelopetype(tbmtype), devicetype(roctype), lastSample(0x4000), pos(0) {}
   dtbSource() : connected(false) {}
     bool isConnected() { return connected; }
 

--- a/core/hal/hal.cc
+++ b/core/hal/hal.cc
@@ -1727,15 +1727,21 @@ void hal::daqStart(uint8_t deser160phase, uint32_t buffersize) {
   buffersize /= m_tokenchains.size();
 
   // Start all DAQ channels we need:
+  uint8_t rocid_offset = 0;
   for(size_t i = 0; i < m_tokenchains.size(); i++) {
     // Start DAQ in channel i:
     uint32_t allocated_buffer = _testboard->Daq_Open(buffersize,i);
-    LOG(logDEBUGHAL) << "Channel " << i << ": token chain: " << static_cast<int>(m_tokenchains.at(i)) << " offset " << 0 << " buffer " << allocated_buffer;
-    m_src.at(i) = dtbSource(_testboard,i,m_tokenchains,m_tbmtype,m_roctype,true);
+    LOG(logDEBUGHAL) << "Channel " << i << ": token chain: "
+		     << (m_notokenpass.at(i) ? 0 : static_cast<int>(m_tokenchains.at(i)))
+		     << " offset " << static_cast<int>(rocid_offset) << " buffer " << allocated_buffer;
+    // Initialize the data source, set tokenchain length to zero of no token pass is expected:
+    m_src.at(i) = dtbSource(_testboard,i,(m_notokenpass.at(i) ? 0 : m_tokenchains.at(i)),rocid_offset,m_tbmtype,m_roctype,true);
     m_src.at(i) >> m_splitter.at(i);
     _testboard->uDelay(100);
     _testboard->Daq_Start(i);
     m_daqstatus.at(i) = true;
+    // Increment the ROC id offset by the amount of ROCs expected:
+    rocid_offset += m_tokenchains.at(i);
   }
   
   _testboard->uDelay(100);

--- a/core/hal/hal.cc
+++ b/core/hal/hal.cc
@@ -291,27 +291,31 @@ bool hal::flashTestboard(std::ifstream& flashFile) {
   return false;
 }
 
-void hal::initTBMCore(uint8_t type, std::map< uint8_t,uint8_t > regVector, std::vector<uint8_t> tokenchains, bool notokenpass) {
+void hal::initTBMCore(tbmConfig tbm) {
 
   // Turn the TBM on:
   _testboard->tbm_Enable(true);
+  
   // Store the token chain lengths:
-  m_tbmtype = type;
-  for(std::vector<uint8_t>::iterator i = tokenchains.begin(); i != tokenchains.end(); i++) {
+  m_tbmtype = tbm.type;
+  for(std::vector<uint8_t>::iterator i = tbm.tokenchains.begin(); i != tbm.tokenchains.end(); i++) {
+    // One tokenchain and no-token-pass setting per TBM channel:
     m_tokenchains.push_back(*i);
+    m_notokenpass.push_back(tbm.notokenpass);
   }
-
-  m_notokenpass.push_back(notokenpass);
+  
+  LOG(logDEBUGHAL) << "This TBM core has NoTokenPass enabled: " << static_cast<int>(tbm.notokenpass);
 
   // Set the hub address for the modules (BPIX default is 31)
+  // FIXME add hubid to tbmConfig!
   LOG(logDEBUGHAL) << "Module addr is " << static_cast<int>(hubId) << ".";
   _testboard->mod_Addr(hubId);
   _testboard->Flush();
 
   // Program all registers according to the configuration data:
   LOG(logDEBUGHAL) << "Setting register vector for TBM Core "
-		   << ((regVector.begin()->first&0xF0) == 0xE0 ? "alpha" : "beta") << ".";
-  tbmSetRegs(regVector);
+		   << ((tbm.dacs.begin()->first&0xF0) == 0xE0 ? "alpha" : "beta") << ".";
+  tbmSetRegs(tbm.dacs);
 }
 
 void hal::setTBMType(uint8_t type) {

--- a/core/hal/hal.cc
+++ b/core/hal/hal.cc
@@ -1681,7 +1681,26 @@ void hal::daqStart(uint8_t deser160phase, uint32_t buffersize) {
     LOG(logCRITICAL) << "Cannot serve " << m_tokenchains.size() << " DAQ channels, only " << DTB_DAQ_CHANNELS << " available.";
     throw InvalidConfig("Number of requested DAQ channels too high");
   }
-  
+
+    // Split the total buffer size when having more than one channel
+  buffersize /= m_tokenchains.size();
+
+  // Open all DAQ channels we need:
+  uint8_t rocid_offset = 0;
+  for(size_t i = 0; i < m_tokenchains.size(); i++) {
+    // Open DAQ in channel i:
+    uint32_t allocated_buffer = _testboard->Daq_Open(buffersize,i);
+    LOG(logDEBUGHAL) << "Channel " << i << ": token chain: "
+		     << (m_notokenpass.at(i) ? 0 : static_cast<int>(m_tokenchains.at(i)))
+		     << " offset " << static_cast<int>(rocid_offset) << " buffer " << allocated_buffer;
+    // Initialize the data source, set tokenchain length to zero of no token pass is expected:
+    m_src.at(i) = dtbSource(_testboard,i,(m_notokenpass.at(i) ? 0 : m_tokenchains.at(i)),rocid_offset,m_tbmtype,m_roctype,true);
+    m_src.at(i) >> m_splitter.at(i);
+    _testboard->uDelay(100);
+    // Increment the ROC id offset by the amount of ROCs expected:
+    rocid_offset += m_tokenchains.at(i);
+  }
+
   // Data acquisition with real TBM:
   if(m_tbmtype != TBM_NONE && m_tbmtype != TBM_EMU) {
     // Check if we have all information needed concerning the token chains:
@@ -1729,26 +1748,13 @@ void hal::daqStart(uint8_t deser160phase, uint32_t buffersize) {
       _testboard->Daq_Select_Deser160(deser160phase);
     }
   }
-  
-  // Split the total buffer size when having more than one channel
-  buffersize /= m_tokenchains.size();
 
-  // Start all DAQ channels we need:
-  uint8_t rocid_offset = 0;
+  // Start all open DAQ channels:
   for(size_t i = 0; i < m_tokenchains.size(); i++) {
     // Start DAQ in channel i:
-    uint32_t allocated_buffer = _testboard->Daq_Open(buffersize,i);
-    LOG(logDEBUGHAL) << "Channel " << i << ": token chain: "
-		     << (m_notokenpass.at(i) ? 0 : static_cast<int>(m_tokenchains.at(i)))
-		     << " offset " << static_cast<int>(rocid_offset) << " buffer " << allocated_buffer;
-    // Initialize the data source, set tokenchain length to zero of no token pass is expected:
-    m_src.at(i) = dtbSource(_testboard,i,(m_notokenpass.at(i) ? 0 : m_tokenchains.at(i)),rocid_offset,m_tbmtype,m_roctype,true);
-    m_src.at(i) >> m_splitter.at(i);
     _testboard->uDelay(100);
     _testboard->Daq_Start(i);
     m_daqstatus.at(i) = true;
-    // Increment the ROC id offset by the amount of ROCs expected:
-    rocid_offset += m_tokenchains.at(i);
   }
   
   _testboard->uDelay(100);

--- a/core/hal/hal.h
+++ b/core/hal/hal.h
@@ -55,7 +55,7 @@ namespace pxar {
 
     /** Initialize attached TBMs with their settings and configuration
      */
-    void initTBMCore(uint8_t type, std::map< uint8_t,uint8_t > regVector, std::vector<uint8_t> tokenchains, bool notokenpass);
+    void initTBMCore(tbmConfig tbm);
 
     /** Change the type of the TBM type member in HAL
      */

--- a/core/hal/hal.h
+++ b/core/hal/hal.h
@@ -113,19 +113,20 @@ namespace pxar {
      */
     bool rocSetDACs(uint8_t roci2c, std::map< uint8_t, uint8_t > dacPairs);
 
-    /** Set a register on a specific TBM tbmId
+    /** Set a register on a specific TBM at hubid
      */
-    bool tbmSetReg(uint8_t regId, uint8_t regValue);
+    bool tbmSetReg(uint8_t hubid, uint8_t regId, uint8_t regValue);
 
     /** Set all registers on a specific TBM tbmId
      *  registers are provided as map of uint8_t,uint8_t pairs with Reg Id and value.
      */
-    bool tbmSetRegs(std::map< uint8_t, uint8_t > regPairs);
+    bool tbmSetRegs(uint8_t hubid, uint8_t core, std::map< uint8_t, uint8_t > regPairs);
 
-    /** Set no token pass so that token chain lengths of zero are used
+    /** Set no token pass so that token chain lengths of zero are used. tbmid is here the number of the
+	TBM core, not the hubid. channels marks, how many channels need to be flagged on this core
      */
-    void tbmSetNoTokenPass(uint8_t tbmid, bool notokenpass);
-
+    void tbmSetNoTokenPass(uint8_t tbmid, uint8_t channels, bool notokenpass);
+    
     /** Function to set and update the pattern generator command list on the DTB
      */
     void SetupPatternGenerator(std::vector<std::pair<uint16_t,uint8_t> > pg_setup, uint16_t delaysum);

--- a/tests/PixTestAlive.cc
+++ b/tests/PixTestAlive.cc
@@ -120,19 +120,8 @@ void PixTestAlive::doTest() {
   bigBanner(Form("PixTestAlive::doTest()"));
 
   aliveTest();
-//   TH1 *h1 = (*fDisplayedHist); 
-//   h1->Draw(getHistOption(h1).c_str());
-//   PixTest::update(); 
-
   maskTest();
-//   h1 = (*fDisplayedHist); 
-//   h1->Draw(getHistOption(h1).c_str());
-//   PixTest::update(); 
-
   addressDecodingTest();
-//   h1 = (*fDisplayedHist); 
-//   h1->Draw(getHistOption(h1).c_str());
-//   PixTest::update(); 
    
   int seconds = t.RealTime(); 
   LOG(logINFO) << "PixTestAlive::doTest() done, duration: " << seconds << " seconds";
@@ -226,22 +215,21 @@ void PixTestAlive::maskTest() {
 
   vector<int> maskPixel(test2.size(), 0); 
   vector<TH2D*> testPixelAlive = mapsWithString("PixelAlive");
+  bool deleteIt(false);
   if (testPixelAlive.size() > 0) {
     LOG(logINFO) << "mask vs. old pixelAlive " 
 		 << testPixelAlive[0]->GetName() << " ..  " << testPixelAlive[testPixelAlive.size()-1]->GetName();
   } else { 
+    deleteIt = true;
     testPixelAlive = efficiencyMaps("PixelAlive", fParNtrig, FLAG_FORCE_MASKED); 
     LOG(logINFO) << "mask vs. new pixelAlive " 
 		 << testPixelAlive[0]->GetName() << " ..  " << testPixelAlive[testPixelAlive.size()-1]->GetName();
   }
 
-  //  double levels[] = {-1., 0., 1.};
-
   for (unsigned int i = 0; i < test2.size(); ++i) {
     fHistOptions[test2[i]] = "coltristate";
     test2[i]->SetMinimum(-1.);
     test2[i]->SetMaximum(1.);
-    //    test2[i]->SetContour((sizeof(levels)/sizeof(Double_t)), levels);
     for (int ix = 0; ix < test2[i]->GetNbinsX(); ++ix) {
       for (int iy = 0; iy < test2[i]->GetNbinsY(); ++iy) {
 	if (test2[i]->GetBinContent(ix+1, iy+1) > 0) {
@@ -265,6 +253,14 @@ void PixTestAlive::maskTest() {
     }
   }
 
+  // -- delete local pixelAlive histograms (but do not touch in case they were taken from fHistList)
+  if (deleteIt) {
+    for (unsigned int i = 0; i < testPixelAlive.size(); ++i) {
+      delete testPixelAlive[i]; 
+    }
+  }
+  testPixelAlive.clear();
+    
   copy(test2.begin(), test2.end(), back_inserter(fHistList));
   
   TH2D *h = (TH2D*)(fHistList.back());

--- a/tests/PixTestAlive.cc
+++ b/tests/PixTestAlive.cc
@@ -265,10 +265,6 @@ void PixTestAlive::maskTest() {
     }
   }
 
-  // -- TEST TEST
-  test2[0]->SetBinContent(11, 16, -1); 
-  test2[15]->SetBinContent(11, 16, -1); 
-
   copy(test2.begin(), test2.end(), back_inserter(fHistList));
   
   TH2D *h = (TH2D*)(fHistList.back());
@@ -339,10 +335,6 @@ void PixTestAlive::addressDecodingTest() {
       }
     }
   }
-
-  // -- TEST TEST
-  test2[0]->SetBinContent(11, 16, -1); 
-  test2[15]->SetBinContent(11, 16, -1); 
 
   copy(test2.begin(), test2.end(), back_inserter(fHistList));
 

--- a/tests/PixTestAlive.cc
+++ b/tests/PixTestAlive.cc
@@ -133,7 +133,7 @@ void PixTestAlive::doTest() {
 void PixTestAlive::aliveTest() {
   cacheDacs();
   fDirectory->cd();
-  //?  PixTest::update(); 
+  PixTest::update(); 
   string ctrlregstring = getDacsString("ctrlreg"); 
   banner(Form("PixTestAlive::aliveTest() ntrig = %d, vcal = %d (ctrlreg = %s)", 
 	      static_cast<int>(fParNtrig), static_cast<int>(fParVcal), ctrlregstring.c_str()));
@@ -148,7 +148,6 @@ void PixTestAlive::aliveTest() {
   vector<int> deadPixel(test2.size(), 0); 
   vector<int> probPixel(test2.size(), 0); 
   for (unsigned int i = 0; i < test2.size(); ++i) {
-    fHistOptions.insert(make_pair(test2[i], "col"));
     // -- count dead pixels
     for (int ix = 0; ix < test2[i]->GetNbinsX(); ++ix) {
       for (int iy = 0; iy < test2[i]->GetNbinsY(); ++iy) {
@@ -173,6 +172,7 @@ void PixTestAlive::aliveTest() {
     PixTest::update(); 
   }
 
+
   restoreDacs();
 
   // -- summary printout
@@ -186,8 +186,6 @@ void PixTestAlive::aliveTest() {
   LOG(logINFO) << "number of dead pixels (per ROC): " << deadPixelString;
   LOG(logDEBUG) << "number of red-efficiency pixels: " << probPixelString;
 
-  //  PixTest::hvOff();
-  //  PixTest::powerOff(); 
 }
 
 
@@ -196,7 +194,7 @@ void PixTestAlive::maskTest() {
 
   cacheDacs();
   fDirectory->cd();
-  //?  PixTest::update(); 
+  PixTest::update(); 
 
   string ctrlregstring = getDacsString("ctrlreg"); 
   banner(Form("PixTestAlive::maskTest() ntrig = %d, vcal = %d (ctrlreg = %s)", 
@@ -292,7 +290,7 @@ void PixTestAlive::addressDecodingTest() {
 
   cacheDacs();
   fDirectory->cd();
-  //?  PixTest::update(); 
+  PixTest::update(); 
   string ctrlregstring = getDacsString("ctrlreg"); 
   banner(Form("PixTestAlive::addressDecodingTest() ntrig = %d, vcal = %d (ctrlreg = %s)", 
 	      static_cast<int>(fParNtrig), static_cast<int>(fParVcal), ctrlregstring.c_str()));


### PR DESCRIPTION
This PR adds
 * correct handling of the NoTokenPass bits: if this is set via the TBM registers, pxarCore automatically picks up the bit and sets the number of expected ROCs to zero in the corresponding decoder module. This means activating NTP on any TBM port always leads to the correct ROC header expectation, and also ROC ID numbering. Thanks to @aehart!
 * The daqStart() function is more flexible now and should be prepared to handle two TBMs on one module. also, the API has been extended accepting a vector of HUB IDs instead of just a single one. For multiple TBMs, one HUB IDs have to be provided per physical TBM. These numbers are cross checked (no. of hub ids vs. number of TBM register vectors)

This code has been tested and validated by @aehart using a TBM08b module w/ psi46digv2.1 chips.