### PR TITLE
change axis range of 1D plots to avoid fitting peaks at zero

### DIFF
--- a/tests/PixTestBB3Map.cc
+++ b/tests/PixTestBB3Map.cc
@@ -191,8 +191,12 @@ void PixTestBB3Map::doTest() {
 
   // loop over the 1D distribution pairs (one for each ROC)
   for (unsigned int i = 0; i < dlist.size(); ++i) {
+
     distEven = (TH1D*)dlist[i].first;
-    distOdd = (TH1D*)dlist[i].second;
+    distOdd  = (TH1D*)dlist[i].second;
+    distEven->GetXaxis()->SetRangeUser(10.,256.);
+    distOdd->GetXaxis()->SetRangeUser(10.,256.);
+
     // search for peaks in the distribution
     // sigma = 5, threshold = 50%
     // peaks below threshold*max_peak_height are discarded
@@ -200,6 +204,8 @@ void PixTestBB3Map::doTest() {
     //   from the distribution
     nPeaksEven = s.Search(distEven, 5, "nobackground", 0.5);
     nPeaksOdd = s.Search(distOdd, 5, "nobackground", 0.5);
+    distEven->GetXaxis()->UnZoom();
+    distOdd->GetXaxis()->UnZoom();
 
     // use fitPeaks algorithm to get the fitted gaussian of good bumps
     fitEven = fitPeaks(distEven, s, nPeaksEven);


### PR DESCRIPTION
Hi,

We recently had an FPix module in which ~3/4 of the pixels in one ROC weren't responding, creating a spike at zero in the BB3 test, which ruined the fitting for the remaining good pixels.  The solution implemented here temporarily rezooms the plot axis to avoid considering the spike at zero when fitting.  Tested on the module in question, issue was resolved.

Jamie