### PR TITLE
Added No Token Pass Option

### DIFF
--- a/core/hal/hal.cc
+++ b/core/hal/hal.cc
@@ -1682,6 +1682,8 @@ void hal::daqStart(uint8_t deser160phase, uint32_t buffersize) {
 
   // Figure out the number of DAQ channels we need:
   if(m_tokenchains.empty()) { m_tokenchains.push_back(m_roccount); }
+  if(m_notokenpass.empty()) { m_notokenpass.push_back(false); }
+  
   LOG(logDEBUGHAL) << "Number of token chains: " << m_tokenchains.size();
   if(m_tokenchains.size() > DTB_DAQ_CHANNELS) {
     LOG(logCRITICAL) << "Cannot serve " << m_tokenchains.size() << " DAQ channels, only " << DTB_DAQ_CHANNELS << " available.";

--- a/main/mkConfig
+++ b/main/mkConfig
@@ -631,6 +631,7 @@ showFits            checkbox(0)
 extended            checkbox(0)
 dumpHists           checkbox(0)
 Ntrig               10
+vcalstep            10
 measure             button
 fit                 button
 save                button

--- a/tests/PixTestGainPedestal.cc
+++ b/tests/PixTestGainPedestal.cc
@@ -23,7 +23,7 @@ ClassImp(PixTestGainPedestal)
 
 // ----------------------------------------------------------------------
 PixTestGainPedestal::PixTestGainPedestal(PixSetup *a, std::string name) : PixTest(a, name), 
-  fParNtrig(-1), fParShowFits(0), fParExtended(0), fParDumpHists(0)  {
+  fParNtrig(-1), fParShowFits(0), fParExtended(0), fParDumpHists(0), fVcalStep(-1)  {
   PixTest::init();
   init(); 
 
@@ -77,6 +77,10 @@ bool PixTestGainPedestal::setParameter(string parName, string sval) {
 	PixUtil::replaceAll(sval, "checkbox(", "");
 	PixUtil::replaceAll(sval, ")", "");
 	fParDumpHists = atoi(sval.c_str()); 
+      }
+      if (!parName.compare("vcalstep")) {
+        fVcalStep = atoi(sval.c_str());
+        LOG(logDEBUG) << "PixTestGainPedestal::PixTest() fVcalStep = " << fVcalStep;
       }
       setToolTips();
       break;
@@ -189,11 +193,10 @@ void PixTestGainPedestal::measure() {
 
 
   fLpoints.clear();
-  fLpoints.push_back(50); 
-  fLpoints.push_back(100); 
-  fLpoints.push_back(150); 
-  fLpoints.push_back(200); 
-  fLpoints.push_back(250); 
+
+  for( int value = 10; value <= 250; value += fVcalStep ){
+    fLpoints.push_back(value);
+  }
 
   fHpoints.clear();
   if (1 == fParExtended) {

--- a/tests/PixTestGainPedestal.hh
+++ b/tests/PixTestGainPedestal.hh
@@ -26,7 +26,7 @@ public:
 
 private:
 
-  int         fParNtrig, fParShowFits, fParExtended, fParDumpHists;
+  int         fParNtrig, fParShowFits, fParExtended, fParDumpHists, fVcalStep;
 
   std::vector<shist256*>  fHists;
   std::vector<int>        fLpoints, fHpoints;

--- a/tests/PixTestTiming.cc
+++ b/tests/PixTestTiming.cc
@@ -269,8 +269,8 @@ void PixTestTiming::PhaseScan() {
       LOG(logDEBUG) << "160MHz Phase: " << iclk160 << " 400MHz Phase: " << iclk400 << " Delay Setting: " << bitset<8>(delaysetting).to_string();
       fApi->setTbmReg("basee", delaysetting, 0); //Set TBM 160-400 MHz Clock Phase
       int NFunctionalROCPhases = 0;
-      fApi->daqStart();
       for (int ithtdelay = 0; ithtdelay < 4; ithtdelay++) {
+        fApi->daqStart();
         //if (ithtdelay==2) continue;
         h3 = bookTH2D(Form("ROCDelayScan_%d_%d",delaysetting/4,ithtdelay),Form("ROC Delay Scan: 160MHz Phase = %d 400MHz Phase = %d THT Delay = %d",iclk160,iclk400,ithtdelay), 8, -0.5, 7.5, 8, -0.5, 7.5);
         h3->SetDirectory(fDirectory);
@@ -295,8 +295,8 @@ void PixTestTiming::PhaseScan() {
           }
         }
         if (h3->GetEntries()>0) rocdelayhists.push_back(h3);
+        fApi->daqStop();
       }
-      fApi->daqStop();
       if (NFunctionalROCPhases>0) {
         NFunctionalTBMPhases++;
         h1->Fill(iclk160,iclk400);
@@ -408,8 +408,8 @@ void PixTestTiming::ROCDelayScan() {
   TH2D *h1(0);
   vector<TH2D*> rocdelayhists;
 
-  fApi->daqStart();
   for (int ithtdelay = 0; ithtdelay < 4; ithtdelay++) {
+    fApi->daqStart();
     //if (ithtdelay==2) continue;
     h1 = bookTH2D(Form("ROCDelayScan%d",ithtdelay),Form("ROC Delay Scan: THT Delay = %d",ithtdelay), 8, -0.5, 7.5, 8, -0.5, 7.5);
     h1->SetDirectory(fDirectory);
@@ -430,8 +430,8 @@ void PixTestTiming::ROCDelayScan() {
       }
     }
     rocdelayhists.push_back(h1);
+    fApi->daqStop();
   }
-  fApi->daqStop();
   
   //Draw plots
   for (size_t ihist = 0; ihist < rocdelayhists.size(); ihist++) {


### PR DESCRIPTION
Hey Simon and Urs,

I added a no token pass option into the timing test, which works great with the work that Andrew and Simon did in the decoder. Additionally, I changed one line of the gain-ped test where if the user selects a small step size they couldn't go below the start value of 10 or the stop value of 250. A user can now scan the whole small vcal range (1 to 255).

Doug