### PR TITLE
Changes in PixTestReadback for improved calculation of the patter period.

### DIFF
--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -1428,7 +1428,7 @@ uint16_t pxarCore::daqTrigger(uint32_t nTrig, uint16_t period) {
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {
     period = _dut->pg_sum;
-    LOG(logWARNING) << "Loop period setting ("<<inputperiod<<") too small for configured "
+    LOG(logWARNING) << "Loop period setting (" << inputperiod << ") too small for configured "
 		    << "Pattern generator. "
 		    << "Forcing loop delay to " << period << " clk";
     LOG(logWARNING) << "To suppress this warning supply a larger delay setting";
@@ -1446,7 +1446,7 @@ uint16_t pxarCore::daqTriggerLoop(uint16_t period) {
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {
     period = _dut->pg_sum;
-    LOG(logWARNING) << "Loop period setting ("<<inputperiod<<") too small for configured "
+    LOG(logWARNING) << "Loop period setting (" << inputperiod << ") too small for configured "
 		    << "Pattern generator. "
 		    << "Forcing loop delay to " << period << " clk";
     LOG(logWARNING) << "To suppress this warning supply a larger delay setting";

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -1423,11 +1423,12 @@ bool pxarCore::daqStatus(uint8_t & perFull) {
 uint16_t pxarCore::daqTrigger(uint32_t nTrig, uint16_t period) {
 
   if(!daqStatus()) { return 0; }
+  int inputperiod=period;
   // Pattern Generator loop doesn't work for delay periods smaller than
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {
     period = _dut->pg_sum;
-    LOG(logWARNING) << "Loop period setting too small for configured "
+    LOG(logWARNING) << "Loop period setting ("<<inputperiod<<") too small for configured "
 		    << "Pattern generator. "
 		    << "Forcing loop delay to " << period << " clk";
     LOG(logWARNING) << "To suppress this warning supply a larger delay setting";
@@ -1440,12 +1441,12 @@ uint16_t pxarCore::daqTrigger(uint32_t nTrig, uint16_t period) {
 uint16_t pxarCore::daqTriggerLoop(uint16_t period) {
 
   if(!daqStatus()) { return 0; }
-
+  int inputperiod=period;
   // Pattern Generator loop doesn't work for delay periods smaller than
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {
     period = _dut->pg_sum;
-    LOG(logWARNING) << "Loop period setting too small for configured "
+    LOG(logWARNING) << "Loop period setting ("<<inputperiod<<") too small for configured "
 		    << "Pattern generator. "
 		    << "Forcing loop delay to " << period << " clk";
     LOG(logWARNING) << "To suppress this warning supply a larger delay setting";

--- a/core/api/api.cc
+++ b/core/api/api.cc
@@ -1423,7 +1423,7 @@ bool pxarCore::daqStatus(uint8_t & perFull) {
 uint16_t pxarCore::daqTrigger(uint32_t nTrig, uint16_t period) {
 
   if(!daqStatus()) { return 0; }
-  int inputperiod=period;
+  uint16_t inputperiod=period;
   // Pattern Generator loop doesn't work for delay periods smaller than
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {
@@ -1441,7 +1441,7 @@ uint16_t pxarCore::daqTrigger(uint32_t nTrig, uint16_t period) {
 uint16_t pxarCore::daqTriggerLoop(uint16_t period) {
 
   if(!daqStatus()) { return 0; }
-  int inputperiod=period;
+  uint16_t inputperiod=period;
   // Pattern Generator loop doesn't work for delay periods smaller than
   // the pattern generator duration, so limit it to that:
   if(period < _dut->pg_sum) {

--- a/tests/PixTestReadback.cc
+++ b/tests/PixTestReadback.cc
@@ -312,7 +312,7 @@ void PixTestReadback::doTest() {
 
 void PixTestReadback::CalibrateIa(){
   LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Starting CalibrateIa()";
+  LOG(logINFO)<<"Running CalibrateIa()";
   prepareDAQ();
   cacheDacs();
   //readback DAC set to 12 (i.e. Ia)
@@ -558,7 +558,7 @@ double PixTestReadback::getCalibratedIa(unsigned int iroc){
 
 void PixTestReadback::CalibrateVd(){
   LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Starting CalibrateVd()";
+  LOG(logINFO)<<"Running CalibrateVd()";
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();
@@ -719,7 +719,7 @@ void PixTestReadback::CalibrateVd(){
 
 void PixTestReadback::readbackVbg(){
   LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Starting readbackVbg())";
+  LOG(logINFO)<<"Running readbackVbg())";
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();
@@ -803,7 +803,7 @@ void PixTestReadback::readbackVbg(){
 
 vector<double> PixTestReadback::getCalibratedVbg(){
   LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Starting getCalibratedVbg()";
+  LOG(logINFO)<<"Running getCalibratedVbg()";
   vector<double> calVbg(fRbVbg.size(), 0.);
   string name="";
   if(fCalwVd){
@@ -855,7 +855,7 @@ vector<double> PixTestReadback::getCalibratedVbg(){
 
 void PixTestReadback::CalibrateVa(){
   LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Starting CalibrateVa()";
+  LOG(logINFO)<<"Running CalibrateVa()";
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();
@@ -1286,7 +1286,7 @@ void PixTestReadback::prepareDAQ(){
   // FIXME - issuing a ROC reset should not be necessary anymore since
   // pxarCore automatically resets the ROC when WBC is changed.
   fApi->daqSingleSignal("resetroc");
-  LOG(logINFO) << "PixTestReadback::RES sent once ";
+  LOG(logDEBUG) << "PixTestReadback::RES sent once ";
 
   //adding triggers to pg
   PreparePG();
@@ -1326,6 +1326,13 @@ void PixTestReadback::PreparePG(){
   //for ROCs: subtract "resetroc"
   int nTbms = fApi->_dut->getNTbms();
   vector<pair<string, uint8_t> > pgtmp = fPixSetup->getConfigParameters()->getTbPgSettings();
+  
+  //for debugging: showing the pattern to be generated
+  LOG(logDEBUG) << "********** The Pattern Generator will be set as following:";
+  if (1) for (unsigned int i = 0; i < pgtmp.size(); ++i){
+    LOG(logDEBUG) << "********** "<<pgtmp[i].first << ": " << (int)pgtmp[i].second;
+  }
+
   for (unsigned i = 0; i < pgtmp.size(); ++i) {
     if(nTbms==0){
       if (string::npos != pgtmp[i].first.find("resetroc")){
@@ -1338,6 +1345,10 @@ void PixTestReadback::PreparePG(){
       }
       if (string::npos != pgtmp[i].first.find("token")){
       LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 1) from "<<ClkDelays;
+      ClkDelays -= pgtmp[i].second+1;
+      }
+      if (string::npos != pgtmp[i].first.find("trigger;sinc")){
+      LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 2) from "<<ClkDelays;
       ClkDelays -= pgtmp[i].second+1;
       }
     }
@@ -1376,6 +1387,7 @@ void PixTestReadback::PreparePG(){
   for(std::vector<std::pair<std::string,uint8_t> >::iterator it = fPg_setup.begin(); it != fPg_setup.end(); ++it){
      if((string)(*it).first==("resetroc")){fParPeriod += (*it).second + 3; LOG(logDEBUG)<<"Adding "<<(*it).first<<": "<<(uint16_t)(*it).second<<" + 3";}
      if((string)(*it).first==("trigger")){fParPeriod += (*it).second + 2;LOG(logDEBUG)<<"Adding "<<(*it).first<<": "<<(uint16_t)(*it).second<<" + 2";}
+     if((string)(*it).first==("trigger;sync")){fParPeriod += (*it).second + 2;LOG(logDEBUG)<<"Adding "<<(*it).first<<": "<<(uint16_t)(*it).second<<" + 2";}
      if((string)(*it).first==("delay")){fParPeriod += (*it).second + 1;LOG(logDEBUG)<<"Adding "<<(*it).first<<": "<<(uint16_t)(*it).second<<" + 1";}
      if((string)(*it).first==("token")){fParPeriod += (*it).second + 1;LOG(logDEBUG)<<"Adding "<<(*it).first<<": "<<(uint16_t)(*it).second<<" + 1";}
   }

--- a/tests/PixTestReadback.cc
+++ b/tests/PixTestReadback.cc
@@ -1334,24 +1334,21 @@ void PixTestReadback::PreparePG(){
   }
 
   for (unsigned i = 0; i < pgtmp.size(); ++i) {
-    if(nTbms==0){
+    if(nTbms==0){  
       if (string::npos != pgtmp[i].first.find("resetroc")){
         LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 3) from "<<ClkDelays;
         ClkDelays -= pgtmp[i].second+3;
       }
-      if (string::npos != pgtmp[i].first.find("trigger")){
-        LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 2) from "<<ClkDelays;
-        ClkDelays -= pgtmp[i].second+2;
-      }
-      if (string::npos != pgtmp[i].first.find("token")){
-      LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 1) from "<<ClkDelays;
-      ClkDelays -= pgtmp[i].second+1;
-      }
-      if (string::npos != pgtmp[i].first.find("trigger;sinc")){
+    }  
+    if (string::npos != pgtmp[i].first.find("trigger")){
       LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 2) from "<<ClkDelays;
-      ClkDelays -= pgtmp[i].second+1;
-      }
+      ClkDelays -= pgtmp[i].second+2;
     }
+    if (string::npos != pgtmp[i].first.find("token")){
+    LOG(logDEBUG)<<"Considering "<<pgtmp[i].first<<" by subtracting ("<< (uint16_t)pgtmp[i].second <<" + 1) from "<<ClkDelays;
+    ClkDelays -= pgtmp[i].second+1;
+    }
+      
   }
 
   //filling the rest of the clock cycles with "delay", taking account, that each delay needs one Clkcycle to be inititated.

--- a/tests/PixTestReadback.cc
+++ b/tests/PixTestReadback.cc
@@ -311,8 +311,7 @@ void PixTestReadback::doTest() {
 
 
 void PixTestReadback::CalibrateIa(){
-  LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Running CalibrateIa()";
+  banner("PixTestReadback::CalibrateIa()");
   prepareDAQ();
   cacheDacs();
   //readback DAC set to 12 (i.e. Ia)
@@ -557,8 +556,7 @@ double PixTestReadback::getCalibratedIa(unsigned int iroc){
 }
 
 void PixTestReadback::CalibrateVd(){
-  LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Running CalibrateVd()";
+  banner("PixTestReadback::CalibrateVd()");
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();
@@ -718,8 +716,7 @@ void PixTestReadback::CalibrateVd(){
 
 
 void PixTestReadback::readbackVbg(){
-  LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Running readbackVbg())";
+  banner("PixTestReadback::readbackVbg()");
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();
@@ -802,8 +799,7 @@ void PixTestReadback::readbackVbg(){
 }
 
 vector<double> PixTestReadback::getCalibratedVbg(){
-  LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Running getCalibratedVbg()";
+  banner("PixTestReadback::getCalibratedVbg()");
   vector<double> calVbg(fRbVbg.size(), 0.);
   string name="";
   if(fCalwVd){
@@ -854,8 +850,7 @@ vector<double> PixTestReadback::getCalibratedVbg(){
 }
 
 void PixTestReadback::CalibrateVa(){
-  LOG(logINFO)<<"*******************************************************";
-  LOG(logINFO)<<"Running CalibrateVa()";
+  banner("PixTestReadback::CalibrateVa()");
   prepareDAQ();
   cacheDacs();
   cachePowerSettings();


### PR DESCRIPTION
This pull request, created together with Pirmin, suggests changes in the Readback Calibration Test. 

1. The main purpose is to calculate the pattern generator (PG) period, as well as the PG-"delays" in a more general way. This will allow a more reliant test with ROCs and a higher adaptability to changes in pxar core.  

2. The whole process of preparing the PG is now only in PixTestReadback::PreparePG(), instead also partly in PixTestReadback::setTrgFrequency(), which is not being used anymore. 

3. Added more DEBUG-logs and DEBUGAPI-logs while reducing INFO-logs making a more efficient parsing of logfiles. Especially more transparency in understanding how the PG is configured and how the PG-period is being calculated.

This change of code was successfully tested on two digv21respin ROCs as well as M2092, M2052 and M2053. 
